### PR TITLE
switch from nose to pytest (and pytest-cov), see also #70

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ script: travis_retry tox
 env:
   - TOXENV=py${TRAVIS_PYTHON_VERSION//[.]/}
   - TOXENV=lint
-  - TOXENV=cover
 
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,5 @@ zip_ok = false
 dev = develop easy_install letsencrypt[testing]
 docs = develop easy_install letsencrypt[docs]
 
-[nosetests]
-nocapture=1
-cover-package=letsencrypt
-cover-erase=1
+[pytest]
+norecursedirs = .git .tox build venv

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,8 @@ docs_extras = [
 ]
 
 testing_extras = [
-    'coverage',
-    'nose',
-    'nosexcover',
+    'pytest',
+    'pytest-cov',
     'pylint<1.4',  # py2.6 compat, c.f #97
     'tox',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26,py27,cover,lint
+envlist = py26,py27,lint
 
 [testenv]
 commands =
     python setup.py dev
-    python setup.py test -q # -q does not suppress errors
-
-[testenv:cover]
-commands =
-    python setup.py dev
-    python setup.py nosetests --with-coverage --cover-min-percentage=47
+    py.test --cov letsencrypt
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
pytest is a more advanced testing framework than nose (IMHO) and makes writing tests a
better experience as one has to type less and has more powerful mechanisms at hand.

Also, in case of a test failure, the output is more helpful in finding the cause.

See: http://pytest.org/latest/

With this changeset, the amount of tests and test fails (none for normal tests, some complaints for pylint) has not changed.

Currently, pytest runs in "compatibility mode", so it is happily executing your existing "written-for-nose" tests.

But future tests (and also existing tests) can now be written with less and prettier code.