### PR TITLE
Add pylint to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'letsencrypt.scripts',
     ],
     install_requires=install_requires,
-    tests_require=install_requires,
+    tests_require=install_requires + ['pylint<1.4',],
     test_suite='letsencrypt',
     extras_require={
         'docs': docs_extras,


### PR DESCRIPTION
Without this change. Travis-CI fails due to pylint not being installed into the virtualenv
in which the tests are run.