### PR TITLE
Make requests certificate verification explicit

### DIFF
--- a/letsencrypt/client/network.py
+++ b/letsencrypt/client/network.py
@@ -47,6 +47,7 @@ class Network(object):
                 self.server_url,
                 data=json_encoded,
                 headers={"Content-Type": "application/json"},
+                verify=True
             )
         except requests.exceptions.RequestException as error:
             raise errors.LetsEncryptClientError(


### PR DESCRIPTION
Quick fix: I believe the default parameter is True, but it should be made explicit in case there are differences between versions.  This should probably involve some form of certificate pinning for the individual CA's domains in the future once the client is closer to release.