### PR TITLE
support --keysize N cmdline param to give RSA key size

### DIFF
--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -339,10 +339,12 @@ def init_key(key_size):
     the namedtuple to easily work with the protocol.
 
     """
-    if key_size < CONFIG.RSA_KEY_SIZE:
-        logging.warning("Generating keys smaller than %d bits is NOT recommended!", CONFIG.RSA_KEY_SIZE)
-
-    key_pem = crypto_util.make_key(key_size)
+    try:
+        key_pem = crypto_util.make_key(key_size)
+    except ValueError as err:
+        logging.fatal(str(err))
+        logging.info("Note: The default RSA key size is %d bits." % CONFIG.RSA_KEY_SIZE)
+        sys.exit(1)
 
     # Save file
     le_util.make_or_verify_dir(CONFIG.KEY_DIR, 0o700)

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -343,7 +343,7 @@ def init_key(key_size):
         key_pem = crypto_util.make_key(key_size)
     except ValueError as err:
         logging.fatal(str(err))
-        logging.info("Note: The default RSA key size is %d bits." % CONFIG.RSA_KEY_SIZE)
+        logging.info("Note: The default RSA key size is %d bits.", CONFIG.RSA_KEY_SIZE)
         sys.exit(1)
 
     # Save file

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -330,7 +330,7 @@ def validate_key_csr(privkey, csr=None):
                     "The key and CSR do not match")
 
 
-def init_key():
+def init_key(key_size):
     """Initializes privkey.
 
     Inits key and CSR using provided files or generating new files
@@ -339,7 +339,10 @@ def init_key():
     the namedtuple to easily work with the protocol.
 
     """
-    key_pem = crypto_util.make_key(CONFIG.RSA_KEY_SIZE)
+    if key_size < CONFIG.RSA_KEY_SIZE:
+        logging.warning("Generating keys smaller than %d bits is NOT recommended!", CONFIG.RSA_KEY_SIZE)
+
+    key_pem = crypto_util.make_key(key_size)
 
     # Save file
     le_util.make_or_verify_dir(CONFIG.KEY_DIR, 0o700)
@@ -348,7 +351,7 @@ def init_key():
     key_f.write(key_pem)
     key_f.close()
 
-    logging.info("Generating key: %s", key_filename)
+    logging.info("Generating key (%d bits): %s", key_size, key_filename)
 
     return Client.Key(key_filename, key_pem)
 

--- a/letsencrypt/client/crypto_util.py
+++ b/letsencrypt/client/crypto_util.py
@@ -145,7 +145,7 @@ def csr_matches_pubkey(csr, privkey):
 
 
 # based on M2Crypto unit test written by Toby Allsopp
-def make_key(bits=CONFIG.RSA_KEY_SIZE):
+def make_key(bits):
     """Generate PEM encoded RSA key.
 
     :param int bits: Number of bits, at least 1024.

--- a/letsencrypt/client/tests/crypto_util_test.py
+++ b/letsencrypt/client/tests/crypto_util_test.py
@@ -98,6 +98,8 @@ class MakeKeyTest(unittest.TestCase):
     def test_it(self):
         from letsencrypt.client.crypto_util import make_key
         M2Crypto.RSA.load_key_string(make_key(1024))
+        M2Crypto.RSA.load_key_string(make_key(2048))
+        M2Crypto.RSA.load_key_string(make_key(4096))
 
 
 class ValidPrivkeyTest(unittest.TestCase):

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -39,7 +39,7 @@ def main():
                         help="Revert configuration N number of checkpoints.")
     parser.add_argument("-B", "--keysize", dest="key_size", type=int,
                         default=CONFIG.RSA_KEY_SIZE, metavar="N",
-                        help="RSA key shall be sized N bits.")
+                        help="RSA key shall be sized N bits. [%d]" % CONFIG.RSA_KEY_SIZE)
     parser.add_argument("-k", "--revoke", dest="revoke", action="store_true",
                         help="Revoke a certificate.")
     parser.add_argument("-v", "--view-config-changes",

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -37,6 +37,9 @@ def main():
     parser.add_argument("-b", "--rollback", dest="rollback", type=int,
                         default=0, metavar="N",
                         help="Revert configuration N number of checkpoints.")
+    parser.add_argument("-B", "--keysize", dest="key_size", type=int,
+                        default=CONFIG.RSA_KEY_SIZE, metavar="N",
+                        help="RSA key shall be sized N bits.")
     parser.add_argument("-k", "--revoke", dest="revoke", action="store_true",
                         help="Revoke a certificate.")
     parser.add_argument("-v", "--view-config-changes",
@@ -100,7 +103,7 @@ def main():
 
     # Prepare for init of Client
     if args.privkey is None:
-        privkey = client.init_key()
+        privkey = client.init_key(args.key_size)
     else:
         privkey = client.Client.Key(args.privkey[0], args.privkey[1])
 


### PR DESCRIPTION
also: improve tests for usual key sizes

note: I would have liked -b N for the bitsize, but -b is already used otherwise.

i ran tox, no issues, also did practical tests and got certificates issued with 1024, 2048, 3072, 4096 and 8192 bits. the latter is ofc a bit slow, but I think we only should check the lower boundary.