### PR TITLE
talk to servers on non-standard https port (like -s acme.example.org:8443)

### DIFF
--- a/letsencrypt/client/CONFIG.py
+++ b/letsencrypt/client/CONFIG.py
@@ -2,8 +2,8 @@
 import os.path
 
 
-ACME_SERVER = "letsencrypt-demo.org"
-"""CA hostname.
+ACME_SERVER = "letsencrypt-demo.org:443"
+"""CA hostname (and optionally :port).
 
 If you create your own server... change this line
 

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -59,7 +59,6 @@ class Client(object):
         :type dv_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
 
         """
-        sanity_check_names([server])
         self.network = network.Network(server)
         self.authkey = authkey
 

--- a/letsencrypt/client/network.py
+++ b/letsencrypt/client/network.py
@@ -17,11 +17,15 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 class Network(object):
     """Class for communicating with ACME servers.
 
-    :ivar str server: Certificate authority server (server[:port])
-    :ivar str server_url: Full URL of the CSR server
+    :ivar str server_url: Full URL of the ACME service
 
     """
     def __init__(self, server):
+        """Initialize Network instance.
+
+        :param str server: ACME (CA) server[:port]
+
+        """
         self.server_url = "https://%s/acme/" % server
 
     def send(self, msg):

--- a/letsencrypt/client/network.py
+++ b/letsencrypt/client/network.py
@@ -17,13 +17,12 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 class Network(object):
     """Class for communicating with ACME servers.
 
-    :ivar str server: Certificate authority server
+    :ivar str server: Certificate authority server (server[:port])
     :ivar str server_url: Full URL of the CSR server
 
     """
     def __init__(self, server):
-        self.server = server
-        self.server_url = "https://%s/acme/" % self.server
+        self.server_url = "https://%s/acme/" % server
 
     def send(self, msg):
         """Send ACME message to server.

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -30,7 +30,8 @@ def main():
     parser.add_argument("-d", "--domains", dest="domains", metavar="DOMAIN",
                         nargs="+")
     parser.add_argument("-s", "--server", dest="server",
-                        help="The ACME CA server [%s]." % CONFIG.ACME_SERVER)
+                        default=CONFIG.ACME_SERVER,
+                        help="The ACME CA server. [%(default)s]")
     parser.add_argument("-p", "--privkey", dest="privkey", type=read_file,
                         help="Path to the private key file for certificate "
                              "generation.")
@@ -72,10 +73,9 @@ def main():
     zope.component.provideUtility(displayer)
 
     installer = determine_installer()
-    server = CONFIG.ACME_SERVER if args.server is None else args.server
 
     if args.revoke:
-        revoc = revoker.Revoker(server, installer)
+        revoc = revoker.Revoker(args.server, installer)
         revoc.list_certs_keys()
         sys.exit()
 
@@ -104,7 +104,7 @@ def main():
     else:
         privkey = client.Client.Key(args.privkey[0], args.privkey[1])
 
-    acme = client.Client(server, privkey, auth, installer)
+    acme = client.Client(args.server, privkey, auth, installer)
 
     # Validate the key and csr
     client.validate_key_csr(privkey)

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -30,7 +30,7 @@ def main():
     parser.add_argument("-d", "--domains", dest="domains", metavar="DOMAIN",
                         nargs="+")
     parser.add_argument("-s", "--server", dest="server",
-                        help="The ACME CA server address.")
+                        help="The ACME CA server [%s]." % CONFIG.ACME_SERVER)
     parser.add_argument("-p", "--privkey", dest="privkey", type=read_file,
                         help="Path to the private key file for certificate "
                              "generation.")


### PR DESCRIPTION
note:

I removed Network.server attribute, it was not used (only .server_url is used).

I also removed the sanity-check for the ACME server (so one can use server:port syntax, which was considered invalid).
I don't think this sanity-check is needed, because in the end, we can't fully check if it is correct anyway (you can always
give valid, but non-working server names or ports).
Also, many people will use the default ACME server, which is builtin and correct.

tested & works.