### PR TITLE
fix for issue #179

### DIFF
--- a/letsencrypt/client/CONFIG.py
+++ b/letsencrypt/client/CONFIG.py
@@ -35,7 +35,7 @@ CERT_KEY_BACKUP = os.path.join(WORK_DIR, "keys-certs/")
 REV_TOKENS_DIR = os.path.join(WORK_DIR, "revocation_tokens/")
 """Directory where all revocation tokens are saved."""
 
-KEY_DIR = os.path.join(SERVER_ROOT, "ssl/")
+KEY_DIR = os.path.join(SERVER_ROOT, "keys/")
 """Where all keys should be stored"""
 
 CERT_DIR = os.path.join(SERVER_ROOT, "certs/")

--- a/letsencrypt/client/le_util.py
+++ b/letsencrypt/client/le_util.py
@@ -49,25 +49,24 @@ def check_permissions(filepath, mode, uid=0):
     return stat.S_IMODE(file_stat.st_mode) == mode and file_stat.st_uid == uid
 
 
-def unique_file(default_name, mode=0o777):
+def unique_file(path, mode=0o777):
     """Safely finds a unique file for writing only (by default).
 
-    :param str default_name: Default file name
+    :param str path: path/filename.ext
     :param int mode: File mode
 
     :return: tuple of file object and file name
 
     """
-    count = 1
-    f_parsed = os.path.splitext(default_name)
-    while 1:
+    path, tail = os.path.split(path)
+    count = 0
+    while True:
+        fname = os.path.join(path, "%04d_%s" % (count, tail))
         try:
-            file_d = os.open(
-                default_name, os.O_CREAT | os.O_EXCL | os.O_RDWR, mode)
-            return os.fdopen(file_d, 'w'), default_name
+            file_d = os.open(fname, os.O_CREAT | os.O_EXCL | os.O_RDWR, mode)
+            return os.fdopen(file_d, 'w'), fname
         except OSError:
             pass
-        default_name = f_parsed[0] + '_' + str(count) + f_parsed[1]
         count += 1
 
 

--- a/letsencrypt/client/tests/le_util_test.py
+++ b/letsencrypt/client/tests/le_util_test.py
@@ -100,26 +100,25 @@ class UniqueFileTest(unittest.TestCase):
         self.assertEqual(0o700, os.stat(self._call(0o700)[1]).st_mode & 0o777)
         self.assertEqual(0o100, os.stat(self._call(0o100)[1]).st_mode & 0o777)
 
-    def test_default_not_exists(self):
-        self.assertEqual(self._call()[1], self.default_name)
-
     def test_default_exists(self):
-        name1 = self._call()[1]  # create foo.txt
+        name1 = self._call()[1]  # create 0000_foo.txt
         name2 = self._call()[1]
         name3 = self._call()[1]
 
         self.assertNotEqual(name1, name2)
-        basename2 = os.path.basename(name2)
-        self.assertEqual(os.path.dirname(name2), self.root_path)
-        self.assertTrue(basename2.startswith('foo'))
-        self.assertTrue(basename2.endswith('.txt'))
-
         self.assertNotEqual(name1, name3)
         self.assertNotEqual(name2, name3)
-        basename3 = os.path.basename(name3)
+
+        self.assertEqual(os.path.dirname(name1), self.root_path)
+        self.assertEqual(os.path.dirname(name2), self.root_path)
         self.assertEqual(os.path.dirname(name3), self.root_path)
-        self.assertTrue(basename3.startswith('foo'))
-        self.assertTrue(basename3.endswith('.txt'))
+
+        basename1 = os.path.basename(name2)
+        self.assertTrue(basename1.endswith('foo.txt'))
+        basename2 = os.path.basename(name2)
+        self.assertTrue(basename2.endswith('foo.txt'))
+        basename3 = os.path.basename(name3)
+        self.assertTrue(basename3.endswith('foo.txt'))
 
 
 # https://en.wikipedia.org/wiki/Base64#Examples


### PR DESCRIPTION
better name for KEY_DIR, improve unique_file, adapt tests

unique_file now generates filenames that sort correctly and also are better
visible / differentiable in narrow file manager filename columns (like e.g. mc).