### PR TITLE
gen_dvsni_chall remove filepath

### DIFF
--- a/letsencrypt/client/challenge_util.py
+++ b/letsencrypt/client/challenge_util.py
@@ -27,11 +27,9 @@ IndexedChall = collections.namedtuple("IndexedChall", "chall, index")
 
 
 # DVSNI Challenge functions
-def dvsni_gen_cert(filepath, name, r_b64, nonce, key):
+def dvsni_gen_cert(name, r_b64, nonce, key):
     """Generate a DVSNI cert and save it to filepath.
 
-    :param str filepath: destination to save certificate. This will overwrite
-        any file that is currently at the location.
     :param str name: domain to validate
     :param str r_b64: jose base64 encoded dvsni r value
     :param str nonce: hex value of nonce
@@ -39,8 +37,10 @@ def dvsni_gen_cert(filepath, name, r_b64, nonce, key):
     :param key: Key to perform challenge
     :type key: :class:`letsencrypt.client.client.Client.Key`
 
-    :returns: dvsni s value jose base64 encoded
-    :rtype: str
+    :returns: tuple of (cert_pem, s) where
+        cert_pem is the certificate in pem form
+        s is the dvsni s value, jose base64 encoded
+    :rtype: tuple
 
     """
     # Generate S
@@ -53,10 +53,7 @@ def dvsni_gen_cert(filepath, name, r_b64, nonce, key):
     cert_pem = crypto_util.make_ss_cert(
         key.pem, [nonce + CONFIG.INVALID_EXT, name, ext])
 
-    with open(filepath, 'w') as chall_cert_file:
-        chall_cert_file.write(cert_pem)
-
-    return le_util.jose_b64encode(dvsni_s)
+    return cert_pem, le_util.jose_b64encode(dvsni_s)
 
 
 def _dvsni_gen_ext(dvsni_r, dvsni_s):

--- a/letsencrypt/client/tests/apache/dvsni_test.py
+++ b/letsencrypt/client/tests/apache/dvsni_test.py
@@ -83,8 +83,8 @@ class DvsniPerformTest(util.ApacheTest):
             (chall.domain, chall.r_b64, chall.nonce, chall.key)
         ]
 
-        for i in range(len(expected_call_list)):
-            for j in range(len(expected_call_list[0])):
+        for i in xrange(len(expected_call_list)):
+            for j in xrange(len(expected_call_list[0])):
                 self.assertEqual(calls[i][0][j], expected_call_list[i][j])
 
     def test_perform1(self):
@@ -129,7 +129,7 @@ class DvsniPerformTest(util.ApacheTest):
                 "Include", self.sni.challenge_conf)),
             1)
         self.assertEqual(len(responses), 2)
-        for i in range(2):
+        for i in xrange(2):
             self.assertEqual(responses[i]["s"], "randomS%d" % i)
 
     def test_mod_config(self):


### PR DESCRIPTION
Just a slight refactor.  I thought I might have been overreaching by automatically saving the dvsni cert at the desired location.  There is an application that doesn't want it saved... the null configurator/stand-alone configurator.

I am kind of on the fence about this and am not positive that this is the best API, but I am attempting to make it as easy as possible to integrate the null configurator/stand-alone configurator (issue #63) correctly.

Refactoring the apache.dvsni.py code did make the testing a bit cleaner.