### PR TITLE
Simpler (and quicker) Travis CI matrix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -322,11 +322,7 @@ max-attributes=7
 min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
-# Pylint counts all of the public methods that you also inherit.
-# This has been reported/fixed as a bug, but until our version is fixed,
-# I think this will only cause us headaches. (Unittests are automatically over)
-# https://bitbucket.org/logilab/pylint/issue/248/too-many-public-methods-triggered-from
-max-public-methods=100
+max-public-methods=20
 
 
 [EXCEPTIONS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,4 @@
-# To mimic README.rst installation and hacking instructions as much as
-# possible, this config file instructs Travis CI to create a build
-# environment for each supported Python version, and then for each of
-# those it runs tox with two environments: lint and pyXX corresponding
-# to the currently used Travis CI build Python version.
-
 language: python
-
-python:
-  - "2.6"
-  - "2.7"
 
 before_install: >
   travis_retry sudo apt-get install python python-setuptools
@@ -18,7 +8,8 @@ install: travis_retry python setup.py dev  # installs tox
 script: travis_retry tox
 
 env:
-  - TOXENV=py${TRAVIS_PYTHON_VERSION//[.]/}
+  - TOXENV=py26
+  - TOXENV=py27
   - TOXENV=lint
   - TOXENV=cover
 

--- a/letsencrypt/client/apache/configurator.py
+++ b/letsencrypt/client/apache/configurator.py
@@ -43,7 +43,7 @@ from letsencrypt.client.apache import parser
 
 
 class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Apache configurator.
 
     State of Configurator: This code has been tested under Ubuntu 12.04

--- a/letsencrypt/client/log.py
+++ b/letsencrypt/client/log.py
@@ -6,7 +6,7 @@ import dialog
 from letsencrypt.client import display
 
 
-class DialogHandler(logging.Handler):
+class DialogHandler(logging.Handler):  # pylint: disable=too-few-public-methods
     """Logging handler using dialog info box.
 
     :ivar int height: Height of the info box (without padding).

--- a/letsencrypt/client/tests/acme_test.py
+++ b/letsencrypt/client/tests/acme_test.py
@@ -42,7 +42,7 @@ class ACMEObjectValidateTest(unittest.TestCase):
         self._test_fails('{"type": "foo", "price": "asd"}')
 
 
-class PrettyTest(unittest.TestCase):
+class PrettyTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
     """Tests for letsencrypt.client.acme.pretty."""
 
     @classmethod

--- a/letsencrypt/client/tests/apache/util.py
+++ b/letsencrypt/client/tests/apache/util.py
@@ -12,7 +12,7 @@ from letsencrypt.client.apache import configurator
 from letsencrypt.client.apache import obj
 
 
-class ApacheTest(unittest.TestCase):
+class ApacheTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
 
     def setUp(self):
         super(ApacheTest, self).setUp()

--- a/letsencrypt/client/tests/crypto_util_test.py
+++ b/letsencrypt/client/tests/crypto_util_test.py
@@ -95,7 +95,7 @@ class CSRMatchesPubkeyTest(unittest.TestCase):
         self.assertFalse(self._call_testdata('csr.pem', RSA512_KEY))
 
 
-class MakeKeyTest(unittest.TestCase):
+class MakeKeyTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
     """Tests for letsencrypt.client.crypto_util.make_key."""
 
     def test_it(self):  # pylint: disable=no-self-use
@@ -124,6 +124,7 @@ class ValidPrivkeyTest(unittest.TestCase):
 
 
 class MakeSSCertTest(unittest.TestCase):
+    # pylint: disable=too-few-public-methods
     """Tests for letsencrypt.client.crypto_util.make_ss_cert."""
 
     def test_it(self):  # pylint: disable=no-self-use
@@ -170,6 +171,7 @@ class GetCertInfoTest(unittest.TestCase):
 
 
 class B64CertToPEMTest(unittest.TestCase):
+    # pylint: disable=too-few-public-methods
     """Tests for letsencrypt.client.crypto_util.b64_cert_to_pem."""
 
     def test_it(self):

--- a/letsencrypt/client/tests/reverter_test.py
+++ b/letsencrypt/client/tests/reverter_test.py
@@ -385,6 +385,7 @@ class TestFullCheckpointsReverter(unittest.TestCase):
 
 
 class QuickInitReverterTest(unittest.TestCase):
+    # pylint: disable=too-few-public-methods
     """Quick test of init."""
     def test_init(self):
         from letsencrypt.client.reverter import Reverter

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ testing_extras = [
     'coverage',
     'nose',
     'nosexcover',
-    'pylint<1.4',  # py2.6 compat, c.f #97
-    'astroid<1.3.0',  # py2.6 compat, c.f. #187
+    'pylint',
     'tox',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ testing_extras = [
     'coverage',
     'nose',
     'nosexcover',
-    'pylint',
+    'pylint>=1.4.0',  # upstream #248
     'tox',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# Tox (http://tox.testrun.org/) is a tool for running tests in
+# multiple virtualenvs. To use it, "pip install tox" and then run
+# "tox" from this directory.
 
 [tox]
 envlist = py26,py27,cover,lint
@@ -12,11 +11,14 @@ commands =
     python setup.py test -q # -q does not suppress errors
 
 [testenv:cover]
+basepython = python2.7
 commands =
     python setup.py dev
     python setup.py nosetests --with-coverage --cover-min-percentage=66
 
 [testenv:lint]
+# recent versions of pylint do not support Python 2.6 (#97, #187)
+basepython = python2.7
 commands =
     python setup.py dev
     pylint --rcfile=.pylintrc letsencrypt


### PR DESCRIPTION
pylint is no longer compatible with Python 2.6 causing numerous problems that we have to address with quickfixes such as #97 and #187. Furthermore, it doesn't actually make sense to run linter on both 2.6 and 2.7 (likewise coverage tests). Matrix is smaller, Travis CI tests are faster.

`max-public-methods` has been reverted back to `20` given that upstream fixed the inheritance problems (starting from 1.4.0).