### PR TITLE
have letsencrypt.VERSION, show it in letsencrypt --help, use it in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.rst CHANGES.rst
 recursive-include letsencrypt *.json
 recursive-include letsencrypt *.sh
 recursive-include letsencrypt *.conf

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,10 +1,3 @@
 """Let's Encrypt."""
 
-# do not import stuff here. this file is used by setup.py, thus importing
-# stuff here might break setup.py as dependencies are not installed yet.
-
-VERSION_TUPLE = 0, 1, 0, "a0"
-"""version tuple: major, minor, micro, {a|b|rc}N - see PEP440"""
-
-VERSION = "%d.%d.%d%s" % VERSION_TUPLE
-"""version as str"""
+__version__ = "0.1"

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,3 +1,2 @@
 """Let's Encrypt."""
-
 __version__ = "0.1"

--- a/letsencrypt/__init__.py
+++ b/letsencrypt/__init__.py
@@ -1,1 +1,10 @@
 """Let's Encrypt."""
+
+# do not import stuff here. this file is used by setup.py, thus importing
+# stuff here might break setup.py as dependencies are not installed yet.
+
+VERSION_TUPLE = 0, 1, 0, "a0"
+"""version tuple: major, minor, micro, {a|b|rc}N - see PEP440"""
+
+VERSION = "%d.%d.%d%s" % VERSION_TUPLE
+"""version as str"""

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -8,6 +8,7 @@ import sys
 import zope.component
 import zope.interface
 
+from letsencrypt import VERSION
 from letsencrypt.client import CONFIG
 from letsencrypt.client import client
 from letsencrypt.client import display
@@ -19,7 +20,7 @@ from letsencrypt.client import log
 def main():  # pylint: disable=too-many-statements,too-many-branches
     """Command line argument parsing and main script execution."""
     parser = argparse.ArgumentParser(
-        description="An ACME client that can update Apache configurations.")
+        description="letsencrypt client %s" % VERSION)
 
     parser.add_argument("-d", "--domains", dest="domains", metavar="DOMAIN",
                         nargs="+")

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -8,7 +8,7 @@ import sys
 import zope.component
 import zope.interface
 
-from letsencrypt import VERSION
+import letsencrypt
 from letsencrypt.client import CONFIG
 from letsencrypt.client import client
 from letsencrypt.client import display
@@ -20,7 +20,7 @@ from letsencrypt.client import log
 def main():  # pylint: disable=too-many-statements,too-many-branches
     """Command line argument parsing and main script execution."""
     parser = argparse.ArgumentParser(
-        description="letsencrypt client %s" % VERSION)
+        description="letsencrypt client %s" % letsencrypt.__version__)
 
     parser.add_argument("-d", "--domains", dest="domains", metavar="DOMAIN",
                         nargs="+")

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
+import codecs
 import os
 import re
-import codecs
 
 from setuptools import setup
 
 
 def read_file(filename, encoding='utf8'):
-    """read unicode from given file"""
+    """Read unicode from given file."""
     with codecs.open(filename, encoding=encoding) as fd:
         return fd.read()
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
+from letsencrypt import VERSION
 
 install_requires = [
     'argparse',
@@ -31,7 +32,7 @@ testing_extras = [
 
 setup(
     name="letsencrypt",
-    version="0.1",
+    version=VERSION,
     description="Let's Encrypt",
     author="Let's Encrypt Project",
     license="",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
+import os
+import re
+import codecs
+
 from setuptools import setup
 
-from letsencrypt import VERSION
+here = os.path.abspath(os.path.dirname(__file__))
+
+# read version number (and other metadata) from package init
+init_fn = os.path.join(here, 'letsencrypt', '__init__.py')
+with codecs.open(init_fn, encoding='utf8') as meta_file:
+    content = meta_file.read()
+meta = dict(re.findall(r"""__([a-z]+)__ = "([^"]+)""", content))
 
 install_requires = [
     'argparse',
@@ -32,7 +42,7 @@ testing_extras = [
 
 setup(
     name="letsencrypt",
-    version=VERSION,
+    version=meta['version'],
     description="Let's Encrypt",
     author="Let's Encrypt Project",
     license="",

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,15 @@ def read_file(filename, encoding='utf8'):
     with codecs.open(filename, encoding=encoding) as fd:
         return fd.read()
 
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 # read version number (and other metadata) from package init
 init_fn = os.path.join(here, 'letsencrypt', '__init__.py')
 meta = dict(re.findall(r"""__([a-z]+)__ = "([^"]+)""", read_file(init_fn)))
+
+readme = read_file(os.path.join(here, 'README.rst'))
+changes = read_file(os.path.join(here, 'CHANGES.rst'))
 
 install_requires = [
     'argparse',
@@ -48,6 +52,7 @@ setup(
     name="letsencrypt",
     version=meta['version'],
     description="Let's Encrypt",
+    long_description=readme,  # later: + '\n\n' + changes
     author="Let's Encrypt Project",
     license="",
     url="https://letsencrypt.org",

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,17 @@ import codecs
 
 from setuptools import setup
 
+
+def read_file(filename, encoding='utf8'):
+    """read unicode from given file"""
+    with codecs.open(filename, encoding=encoding) as fd:
+        return fd.read()
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 # read version number (and other metadata) from package init
 init_fn = os.path.join(here, 'letsencrypt', '__init__.py')
-with codecs.open(init_fn, encoding='utf8') as meta_file:
-    content = meta_file.read()
-meta = dict(re.findall(r"""__([a-z]+)__ = "([^"]+)""", content))
+meta = dict(re.findall(r"""__([a-z]+)__ = "([^"]+)""", read_file(init_fn)))
 
 install_requires = [
     'argparse',


### PR DESCRIPTION
note: we had some discussion about potential problems importing VERSION from main package.

SO link: http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package

See also my comment in __init__.py - maybe we can add that "version detection from git tags" magic later.