### PR TITLE
Patch auth handler cleanup

### DIFF
--- a/letsencrypt/client/auth_handler.py
+++ b/letsencrypt/client/auth_handler.py
@@ -208,9 +208,11 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
         """
         logging.info("Cleaning up challenges for %s", domain)
         # These are indexed challenges... give just the challenges to the auth
-        self.dv_auth.cleanup(ichall.chall for ichall in self.dv_c[domain])
+        # Chose to make these lists instead of a generator to make it easier to
+        # work with...
+        self.dv_auth.cleanup([ichall.chall for ichall in self.dv_c[domain]])
         self.client_auth.cleanup(
-            ichall.chall for ichall in self.client_c[domain])
+            [ichall.chall for ichall in self.client_c[domain]])
 
     def _cleanup_state(self, delete_list):
         """Cleanup state after an authorization is received.

--- a/letsencrypt/client/auth_handler.py
+++ b/letsencrypt/client/auth_handler.py
@@ -299,8 +299,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
         elif chall["type"] == "dns":
             logging.info("  DNS challenge for name %s.", domain)
-            return challenge_util.DnsChall(
-                domain, str(chall["token"]), self.authkey[domain])
+            return challenge_util.DnsChall(domain, str(chall["token"]))
 
         else:
             raise errors.LetsEncryptClientError(

--- a/letsencrypt/client/challenge_util.py
+++ b/letsencrypt/client/challenge_util.py
@@ -13,7 +13,7 @@ from letsencrypt.client import le_util
 DvsniChall = collections.namedtuple("DvsniChall", "domain, r_b64, nonce, key")
 SimpleHttpsChall = collections.namedtuple(
     "SimpleHttpsChall", "domain, token, key")
-DnsChall = collections.namedtuple("DnsChall", "domain, token, key")
+DnsChall = collections.namedtuple("DnsChall", "domain, token")
 
 # Client Challenges
 RecContactChall = collections.namedtuple(

--- a/letsencrypt/client/errors.py
+++ b/letsencrypt/client/errors.py
@@ -9,6 +9,7 @@ class LetsEncryptReverterError(LetsEncryptClientError):
     """Let's Encrypt Reverter error."""
 
 
+# Auth Handler Errors
 class LetsEncryptAuthHandlerError(LetsEncryptClientError):
     """Let's Encrypt Auth Handler error."""
 
@@ -17,6 +18,16 @@ class LetsEncryptClientAuthError(LetsEncryptAuthHandlerError):
     """Let's Encrypt Client Authenticator error."""
 
 
+class LetsEncryptDvAuthError(LetsEncryptAuthHandlerError):
+    """Let's Encrypt DV Authenticator error."""
+
+
+# Authenticator - Challenge specific errors
+class LetsEncryptDvsniError(LetsEncryptDvAuthError):
+    """Let's Encrypt DVSNI error."""
+
+
+# Configurator Errors
 class LetsEncryptConfiguratorError(LetsEncryptClientError):
     """Let's Encrypt Configurator error."""
 
@@ -28,6 +39,3 @@ class LetsEncryptNoInstallationError(LetsEncryptConfiguratorError):
 class LetsEncryptMisconfigurationError(LetsEncryptConfiguratorError):
     """Let's Encrypt Misconfiguration error."""
 
-
-class LetsEncryptDvsniError(LetsEncryptConfiguratorError):
-    """Let's Encrypt DVSNI error."""

--- a/letsencrypt/client/tests/auth_handler_test.py
+++ b/letsencrypt/client/tests/auth_handler_test.py
@@ -123,7 +123,7 @@ class SatisfyChallengesTest(unittest.TestCase):
             acme_util.get_chall_msg(dom, "nonce0", challenges, combos),
             "dummy_key")
 
-        path =gen_path(["simpleHttps", "recoveryToken"], challenges)
+        path = gen_path(["simpleHttps", "recoveryToken"], challenges)
         mock_chall_path.return_value = path
 
         self.handler._satisfy_challenges()  # pylint: disable=protected-access
@@ -141,7 +141,7 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertTrue(isinstance(self.handler.dv_c[dom][0].chall,
                                    challenge_util.SimpleHttpsChall))
         self.assertTrue(isinstance(self.handler.client_c[dom][0].chall,
-                                    challenge_util.RecTokenChall))
+                                   challenge_util.RecTokenChall))
 
     @mock.patch("letsencrypt.client.auth_handler.gen_challenge_path")
     def test_name5_all(self, mock_chall_path):
@@ -175,9 +175,9 @@ class SatisfyChallengesTest(unittest.TestCase):
             self.assertEqual(len(self.handler.client_c[dom]), 1)
 
             self.assertTrue(isinstance(self.handler.dv_c[dom][0].chall,
-                                        challenge_util.DvsniChall))
+                                       challenge_util.DvsniChall))
             self.assertTrue(isinstance(self.handler.client_c[dom][0].chall,
-                                        challenge_util.RecContactChall))
+                                       challenge_util.RecContactChall))
 
     @mock.patch("letsencrypt.client.auth_handler.gen_challenge_path")
     def test_name5_mix(self, mock_chall_path):
@@ -220,7 +220,7 @@ class SatisfyChallengesTest(unittest.TestCase):
                 len(self.handler.client_c[dom]), len(chosen_chall[i]) - 1)
 
         self.assertTrue(isinstance(self.handler.dv_c["0"][0].chall,
-                        challenge_util.DnsChall))
+                                   challenge_util.DnsChall))
         self.assertTrue(isinstance(self.handler.dv_c["1"][0].chall,
                                    challenge_util.DvsniChall))
         self.assertTrue(isinstance(self.handler.dv_c["2"][0].chall,


### PR DESCRIPTION
It came to my attention that auth_handler was sending down IndexedChallenges from challenge_util instead of a list of the raw types for the cleanup function.  I didn't write test_code for the cleanup as it was bound around protocol code (that will change).

I fixed the bug (it wasn't affecting the ApacheConfigurator because it wasn't using the cleanup values... just the length of the list)

I also added a catch around the perform functions so that Authenticators could throw appropriate errors and the AuthHandler could still cleanup.

I added a test case for this new try block which also checks to make sure the cleanup functions are called appropriately.