### PR TITLE
Add libffi-dev to installation

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -24,7 +24,8 @@ Ubuntu
 ::
 
     sudo apt-get install python python-setuptools python-virtualenv python-dev \
-                 gcc swig dialog libaugeas0 libssl-dev ca-certificates
+                 gcc swig dialog libaugeas0 libssl-dev libffi-dev \
+                 ca-certificates
 
 
 Mac OSX


### PR DESCRIPTION
libffi-dev is required by Cryptography which is the base of PyOpenSSL (I think). (Standalone-Authenticator currently uses PyOpenSSL.)

Since Cryptography seems to be the way forward #164. I don't think we should have too many qualms about adding it to the list of dependencies.

The setup of a new venv crashes otherwise.