### PR TITLE
Make coveralls dependent on the TOXENV variable being "cover"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 
 script: travis_retry tox
 
-after_success: coveralls
+after_success: '[ "$TOXENV" == "cover" ] && coveralls'
 
 env:
   - TOXENV=py26


### PR DESCRIPTION
This one-liner stops `coveralls` from running except when the env variable is set to 'cover'. This should resolve issue #253 . 
The travis build works, and all the sub-builds are 0.00s (meaning they skipped):
https://travis-ci.org/letsencrypt/lets-encrypt-preview/builds/52059686