### PR TITLE
Vagrantfile and associated changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ venv/
 .tox/
 .coverage
 m3
+*~
+.vagrant

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,8 +23,33 @@ The following tools are there to help you:
 - ``./venv/bin/tox -e lint`` checks the style of the whole project,
   while ``./venv/bin/pylint --rcfile=.pylintrc file`` will check a single `file` only.
 
-
 .. _coding-style:
+	
+Vagrant
+=======
+
+If you are a Vagrant user, Let's Encrypt comes with a Vagrantfile that automates
+setting up a development environment in an Ubuntu 14.04 LTS VM. To set it up,
+simply run ``vagrant up``. The repository is synced to ``/vagrant``, so you can
+get started with:
+
+::
+
+	 vagrant ssh
+	 cd /vagrant
+	 ./venv/bin/python setup.py install
+	 sudo ./venv/bin/letsencrypt
+
+Support for other Linux distributions coming soon.
+
+**Note:** Unfortunately, Python distutils and, by extension, setup.py and tox,
+use hard linking quite extensively. Hard linking is not supported by the
+default sync filesystem in Vagrant. As a result, all actions with these
+commands are *significantly slower* in Vagrant. One potential fix is to `use
+NFS`_ (`related issue`_).
+
+.. _use NFS: http://docs.vagrantup.com/v2/synced-folders/nfs.html
+.. _related issue: https://github.com/ClusterHQ/flocker/issues/516
 
 Coding style
 ============

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Setup instructions from docs/using.rst
+$ubuntu_setup_script = <<SETUP_SCRIPT
+sudo apt-get update
+sudo apt-get install -y python python-setuptools python-virtualenv python-dev gcc swig dialog libaugeas0 libssl-dev libffi-dev ca-certificates
+
+cd /vagrant
+if [ ! -d "venv" ]; then
+  virtualenv --no-site-packages -p python2 venv
+  ./venv/bin/python setup.py dev
+fi
+SETUP_SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.define "ubuntu-trusty", primary: true do |ubuntu_trusty|
+    ubuntu_trusty.vm.box = "ubuntu/trusty64"
+    ubuntu_trusty.vm.provision "shell", inline: $ubuntu_setup_script
+    ubuntu_trusty.vm.provider "virtualbox" do |v|
+      # VM needs more memory to run test suite, got "OSError: [Errno 12]
+      # Cannot allocate memory" when running
+      # letsencrypt.client.tests.display.util_test.NcursesDisplayTest
+      v.memory = 1024
+    end
+  end
+
+end

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,12 @@ import re
 
 from setuptools import setup
 
+# Workaround for http://bugs.python.org/issue8876, see
+# http://bugs.python.org/issue8876#msg208792
+# This can be removed when using Python 2.7.9 or later:
+# https://hg.python.org/cpython/raw-file/v2.7.9/Misc/NEWS
+if os.path.abspath(__file__).split(os.path.sep)[1] == 'vagrant':
+    del os.link
 
 def read_file(filename, encoding='utf8'):
     """Read unicode from given file."""


### PR DESCRIPTION
Adds a Vagrantfile that automatically sets up a Let's Encrypt development environment in an Ubuntu 14.04 VM. To use:

```sh
vagrant up
vagrant ssh
cd /vagrant
source venv/bin/activate # Vagrant set this up for you already
tox # or whatever
```