### PR TITLE
Rename client authenticator/challenges

### DIFF
--- a/docs/api/client/client_authenticator.rst
+++ b/docs/api/client/client_authenticator.rst
@@ -1,5 +1,0 @@
-:mod:`letsencrypt.client.client_authenticator`
-----------------------------------------------
-
-.. automodule:: letsencrypt.client.client_authenticator
-   :members:

--- a/docs/api/client/continuity_auth.rst
+++ b/docs/api/client/continuity_auth.rst
@@ -1,5 +1,5 @@
 :mod:`letsencrypt.client.continuity_auth`
-----------------------------------------------
+-----------------------------------------
 
 .. automodule:: letsencrypt.client.continuity_auth
    :members:

--- a/docs/api/client/continuity_auth.rst
+++ b/docs/api/client/continuity_auth.rst
@@ -1,0 +1,5 @@
+:mod:`letsencrypt.client.continuity_auth`
+----------------------------------------------
+
+.. automodule:: letsencrypt.client.continuity_auth
+   :members:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -98,15 +98,16 @@ the ACME server. From the protocol, there are essentially two
 different types of challenges. Challenges that must be solved by
 individual plugins in order to satisfy domain validation (subclasses
 of `~.DVChallenge`, i.e. `~.challenges.DVSNI`,
-`~.challenges.SimpleHTTPS`, `~.challenges.DNS`) and client specific
-challenges (subclasses of `~.ClientChallenge`,
+`~.challenges.SimpleHTTPS`, `~.challenges.DNS`) and continuity specific
+challenges (subclasses of `~.ContinuityChallenge`,
 i.e. `~.challenges.RecoveryToken`, `~.challenges.RecoveryContact`,
-`~.challenges.ProofOfPossession`). Client specific challenges are
-always handled by the `~.ClientAuthenticator`. Right now we have two
-DV Authenticators, `~.ApacheConfigurator` and the
-`~.StandaloneAuthenticator`. The Standalone and Apache authenticators
-only solve the `~.challenges.DVSNI` challenge currently. (You can set
-which challenges your authenticator can handle through the
+`~.challenges.ProofOfPossession`). Continuity challenges are
+always handled by the `~.ContinuityAuthenticator`, while plugins are
+expected to handle `~.DVChallenge` types.
+Right now, we have two authenticator plugins, the `~.ApacheConfigurator`
+and the `~.StandaloneAuthenticator`. The Standalone and Apache
+authenticators only solve the `~.challenges.DVSNI` challenge currently.
+(You can set which challenges your authenticator can handle through the
 :meth:`~.IAuthenticator.get_chall_pref`.
 
 (FYI: We also have a partial implementation for a `~.DNSAuthenticator`

--- a/letsencrypt/acme/challenges.py
+++ b/letsencrypt/acme/challenges.py
@@ -18,7 +18,7 @@ class Challenge(jose.TypedJSONObjectWithFields):
     TYPES = {}
 
 
-class ClientChallenge(Challenge):  # pylint: disable=abstract-method
+class ContinuityChallenge(Challenge):  # pylint: disable=abstract-method
     """Client validation challenges."""
 
 
@@ -139,7 +139,7 @@ class DVSNIResponse(ChallengeResponse):
         return self.z(chall) + self.DOMAIN_SUFFIX
 
 @Challenge.register
-class RecoveryContact(ClientChallenge):
+class RecoveryContact(ContinuityChallenge):
     """ACME "recoveryContact" challenge."""
     typ = "recoveryContact"
 
@@ -156,7 +156,7 @@ class RecoveryContactResponse(ChallengeResponse):
 
 
 @Challenge.register
-class RecoveryToken(ClientChallenge):
+class RecoveryToken(ContinuityChallenge):
     """ACME "recoveryToken" challenge."""
     typ = "recoveryToken"
 
@@ -169,7 +169,7 @@ class RecoveryTokenResponse(ChallengeResponse):
 
 
 @Challenge.register
-class ProofOfPossession(ClientChallenge):
+class ProofOfPossession(ContinuityChallenge):
     """ACME "proofOfPossession" challenge.
 
     :ivar str nonce: Random data, **not** base64-encoded.

--- a/letsencrypt/client/auth_handler.py
+++ b/letsencrypt/client/auth_handler.py
@@ -17,12 +17,12 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
     """ACME Authorization Handler for a client.
 
     :ivar dv_auth: Authenticator capable of solving
-        :const:`~letsencrypt.client.constants.DV_CHALLENGES`
+        :const:`~letsencrypt.acme.challenges.DVChallenge`(s)
     :type dv_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
 
-    :ivar client_auth: Authenticator capable of solving
-        :const:`~letsencrypt.client_auth.constants.CLIENT_CHALLENGES`
-    :type client_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
+    :ivar cont_auth: Authenticator capable of solving
+        :const:`~letsencrypt.acme.challenges.ContinuityChallenge`(s)
+    :type cont_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
 
     :ivar network: Network object for sending and receiving authorization
         messages
@@ -37,13 +37,13 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
     :ivar dict paths: optimal path for authorization. eg. paths[domain]
     :ivar dict dv_c: Keys - domain, Values are DV challenges in the form of
         :class:`letsencrypt.client.achallenges.Indexed`
-    :ivar dict client_c: Keys - domain, Values are Client challenges in the form
-        of :class:`letsencrypt.client.achallenges.Indexed`
+    :ivar dict cont_c: Keys - domain, Values are Continuity challenges in the
+        form of :class:`letsencrypt.client.achallenges.Indexed`
 
     """
-    def __init__(self, dv_auth, client_auth, network):
+    def __init__(self, dv_auth, cont_auth, network):
         self.dv_auth = dv_auth
-        self.client_auth = client_auth
+        self.cont_auth = cont_auth
         self.network = network
 
         self.domains = []
@@ -53,7 +53,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
         self.paths = dict()
 
         self.dv_c = dict()
-        self.client_c = dict()
+        self.cont_c = dict()
 
     def add_chall_msg(self, domain, msg, authkey):
         """Add a challenge message to the AuthHandler.
@@ -77,7 +77,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
         self.authkey[domain] = authkey
 
     def get_authorizations(self):
-        """Retreive all authorizations for challenges.
+        """Retrieve all authorizations for challenges.
 
         :raises LetsEncryptAuthHandlerError: If unable to retrieve all
             authorizations
@@ -148,24 +148,24 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
                 self._get_chall_pref(dom),
                 self.msgs[dom].combinations)
 
-            self.dv_c[dom], self.client_c[dom] = self._challenge_factory(
+            self.dv_c[dom], self.cont_c[dom] = self._challenge_factory(
                 dom, self.paths[dom])
 
         # Flatten challs for authenticator functions and remove index
         # Order is important here as we will not expose the outside
         # Authenticator to our own indices.
-        flat_client = []
+        flat_cont = []
         flat_dv = []
 
         for dom in self.domains:
-            flat_client.extend(ichall.achall for ichall in self.client_c[dom])
+            flat_cont.extend(ichall.achall for ichall in self.cont_c[dom])
             flat_dv.extend(ichall.achall for ichall in self.dv_c[dom])
 
-        client_resp = []
+        cont_resp = []
         dv_resp = []
         try:
-            if flat_client:
-                client_resp = self.client_auth.perform(flat_client)
+            if flat_cont:
+                cont_resp = self.cont_auth.perform(flat_cont)
             if flat_dv:
                 dv_resp = self.dv_auth.perform(flat_dv)
         # This will catch both specific types of errors.
@@ -182,8 +182,8 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
         logging.info("Ready for verification...")
 
         # Assemble Responses
-        if client_resp:
-            self._assign_responses(client_resp, self.client_c)
+        if cont_resp:
+            self._assign_responses(cont_resp, self.cont_c)
         if dv_resp:
             self._assign_responses(dv_resp, self.dv_c)
 
@@ -192,7 +192,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
         :param list flat_list: flat_list of responses from an IAuthenticator
         :param dict ichall_dict: Master dict mapping all domains to a list of
-            their associated 'client' and 'dv' Indexed challenges, or their
+            their associated 'continuity' and 'dv' Indexed challenges, or their
             :class:`letsencrypt.client.achallenges.Indexed` list
 
         """
@@ -214,7 +214,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
         """
         chall_prefs = []
-        chall_prefs.extend(self.client_auth.get_chall_pref(domain))
+        chall_prefs.extend(self.cont_auth.get_chall_pref(domain))
         chall_prefs.extend(self.dv_auth.get_chall_pref(domain))
         return chall_prefs
 
@@ -229,11 +229,11 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
         # Chose to make these lists instead of a generator to make it easier to
         # work with...
         dv_list = [ichall.achall for ichall in self.dv_c[domain]]
-        client_list = [ichall.achall for ichall in self.client_c[domain]]
+        cont_list = [ichall.achall for ichall in self.cont_c[domain]]
         if dv_list:
             self.dv_auth.cleanup(dv_list)
-        if client_list:
-            self.client_auth.cleanup(client_list)
+        if cont_list:
+            self.cont_auth.cleanup(cont_list)
 
     def _cleanup_state(self, delete_list):
         """Cleanup state after an authorization is received.
@@ -248,7 +248,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
             del self.authkey[domain]
 
-            del self.client_c[domain]
+            del self.cont_c[domain]
             del self.dv_c[domain]
 
             self.domains.remove(domain)
@@ -260,9 +260,9 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
         :param list path: List of indices from `challenges`.
 
-        :returns: dv_chall, list of
+        :returns: dv_chall, list of DVChallenge type
             :class:`letsencrypt.client.achallenges.Indexed`
-            client_chall, list of
+            cont_chall, list of ContinuityChallenge type
             :class:`letsencrypt.client.achallenges.Indexed`
         :rtype: tuple
 
@@ -271,7 +271,7 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
         """
         dv_chall = []
-        client_chall = []
+        cont_chall = []
 
         for index in path:
             chall = self.msgs[domain].challenges[index]
@@ -305,12 +305,12 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
 
             ichall = achallenges.Indexed(achall=achall, index=index)
 
-            if isinstance(chall, challenges.ClientChallenge):
-                client_chall.append(ichall)
+            if isinstance(chall, challenges.ContinuityChallenge):
+                cont_chall.append(ichall)
             elif isinstance(chall, challenges.DVChallenge):
                 dv_chall.append(ichall)
 
-        return dv_chall, client_chall
+        return dv_chall, cont_chall
 
 
 def gen_challenge_path(challs, preferences, combinations):

--- a/letsencrypt/client/auth_handler.py
+++ b/letsencrypt/client/auth_handler.py
@@ -17,11 +17,11 @@ class AuthHandler(object):  # pylint: disable=too-many-instance-attributes
     """ACME Authorization Handler for a client.
 
     :ivar dv_auth: Authenticator capable of solving
-        :const:`~letsencrypt.acme.challenges.DVChallenge`(s)
+        :class:`~letsencrypt.acme.challenges.DVChallenge` types
     :type dv_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
 
     :ivar cont_auth: Authenticator capable of solving
-        :const:`~letsencrypt.acme.challenges.ContinuityChallenge`(s)
+        :class:`~letsencrypt.acme.challenges.ContinuityChallenge` types
     :type cont_auth: :class:`letsencrypt.client.interfaces.IAuthenticator`
 
     :ivar network: Network object for sending and receiving authorization

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -10,7 +10,7 @@ from letsencrypt.acme import jose
 from letsencrypt.acme import messages
 
 from letsencrypt.client import auth_handler
-from letsencrypt.client import client_authenticator
+from letsencrypt.client import continuity_auth
 from letsencrypt.client import crypto_util
 from letsencrypt.client import errors
 from letsencrypt.client import le_util
@@ -33,7 +33,8 @@ class Client(object):
     :type authkey: :class:`letsencrypt.client.le_util.Key`
 
     :ivar auth_handler: Object that supports the IAuthenticator interface.
-        auth_handler contains both a dv_authenticator and a client_authenticator
+        auth_handler contains both a dv_authenticator and a
+        continuity_authenticator
     :type auth_handler: :class:`letsencrypt.client.auth_handler.AuthHandler`
 
     :ivar installer: Object supporting the IInstaller interface.
@@ -60,9 +61,9 @@ class Client(object):
         self.config = config
 
         if dv_auth is not None:
-            client_auth = client_authenticator.ClientAuthenticator(config)
+            cont_auth = continuity_auth.ContinuityAuthenticator(config)
             self.auth_handler = auth_handler.AuthHandler(
-                dv_auth, client_auth, self.network)
+                dv_auth, cont_auth, self.network)
         else:
             self.auth_handler = None
 

--- a/letsencrypt/client/continuity_auth.py
+++ b/letsencrypt/client/continuity_auth.py
@@ -11,7 +11,7 @@ from letsencrypt.client import recovery_token
 
 class ContinuityAuthenticator(object):
     """IAuthenticator for
-    :const:`~letsencrypt.acme.challenges.ContinuityChallenge`s.
+    :const:`~letsencrypt.acme.challenges.ContinuityChallenge` class challenges.
 
     :ivar rec_token: Performs "recoveryToken" challenges
     :type rec_token: :class:`letsencrypt.client.recovery_token.RecoveryToken`

--- a/letsencrypt/client/continuity_auth.py
+++ b/letsencrypt/client/continuity_auth.py
@@ -1,4 +1,4 @@
-"""Client Authenticator"""
+"""Continuity Authenticator"""
 import zope.interface
 
 from letsencrypt.acme import challenges
@@ -9,9 +9,9 @@ from letsencrypt.client import interfaces
 from letsencrypt.client import recovery_token
 
 
-class ClientAuthenticator(object):
+class ContinuityAuthenticator(object):
     """IAuthenticator for
-    :const:`~letsencrypt.client.constants.CLIENT_CHALLENGES`.
+    :const:`~letsencrypt.acme.challenges.ContinuityChallenge`s.
 
     :ivar rec_token: Performs "recoveryToken" challenges
     :type rec_token: :class:`letsencrypt.client.recovery_token.RecoveryToken`
@@ -41,7 +41,7 @@ class ClientAuthenticator(object):
             if isinstance(achall, achallenges.RecoveryToken):
                 responses.append(self.rec_token.perform(achall))
             else:
-                raise errors.LetsEncryptClientAuthError("Unexpected Challenge")
+                raise errors.LetsEncryptContAuthError("Unexpected Challenge")
         return responses
 
     def cleanup(self, achalls):
@@ -50,4 +50,4 @@ class ClientAuthenticator(object):
             if isinstance(achall, achallenges.RecoveryToken):
                 self.rec_token.cleanup(achall)
             else:
-                raise errors.LetsEncryptClientAuthError("Unexpected Challenge")
+                raise errors.LetsEncryptContAuthError("Unexpected Challenge")

--- a/letsencrypt/client/errors.py
+++ b/letsencrypt/client/errors.py
@@ -14,7 +14,7 @@ class LetsEncryptAuthHandlerError(LetsEncryptClientError):
     """Let's Encrypt Auth Handler error."""
 
 
-class LetsEncryptClientAuthError(LetsEncryptAuthHandlerError):
+class LetsEncryptContAuthError(LetsEncryptAuthHandlerError):
     """Let's Encrypt Client Authenticator error."""
 
 

--- a/letsencrypt/client/tests/acme_util.py
+++ b/letsencrypt/client/tests/acme_util.py
@@ -48,21 +48,21 @@ POP = challenges.ProofOfPossession(
 CHALLENGES = [SIMPLE_HTTPS, DVSNI, DNS, RECOVERY_CONTACT, RECOVERY_TOKEN, POP]
 DV_CHALLENGES = [chall for chall in CHALLENGES
                  if isinstance(chall, challenges.DVChallenge)]
-CLIENT_CHALLENGES = [chall for chall in CHALLENGES
-                     if isinstance(chall, challenges.ClientChallenge)]
+CONT_CHALLENGES = [chall for chall in CHALLENGES
+                     if isinstance(chall, challenges.ContinuityChallenge)]
 
 
 def gen_combos(challs):
     """Generate natural combinations for challs."""
     dv_chall = []
-    renewal_chall = []
+    cont_chall = []
 
     for i, chall in enumerate(challs):  # pylint: disable=redefined-outer-name
         if isinstance(chall, challenges.DVChallenge):
             dv_chall.append(i)
         else:
-            renewal_chall.append(i)
+            cont_chall.append(i)
 
     # Gen combos for 1 of each type, lowest index first (makes testing easier)
     return tuple((i, j) if i < j else (j, i)
-                 for i in dv_chall for j in renewal_chall)
+                 for i in dv_chall for j in cont_chall)

--- a/letsencrypt/client/tests/acme_util.py
+++ b/letsencrypt/client/tests/acme_util.py
@@ -49,7 +49,7 @@ CHALLENGES = [SIMPLE_HTTPS, DVSNI, DNS, RECOVERY_CONTACT, RECOVERY_TOKEN, POP]
 DV_CHALLENGES = [chall for chall in CHALLENGES
                  if isinstance(chall, challenges.DVChallenge)]
 CONT_CHALLENGES = [chall for chall in CHALLENGES
-                     if isinstance(chall, challenges.ContinuityChallenge)]
+                   if isinstance(chall, challenges.ContinuityChallenge)]
 
 
 def gen_combos(challs):

--- a/letsencrypt/client/tests/auth_handler_test.py
+++ b/letsencrypt/client/tests/auth_handler_test.py
@@ -30,17 +30,17 @@ class SatisfyChallengesTest(unittest.TestCase):
         from letsencrypt.client.auth_handler import AuthHandler
 
         self.mock_dv_auth = mock.MagicMock(name="ApacheConfigurator")
-        self.mock_client_auth = mock.MagicMock(name="ClientAuthenticator")
+        self.mock_cont_auth = mock.MagicMock(name="ContinuityAuthenticator")
 
         self.mock_dv_auth.get_chall_pref.return_value = [challenges.DVSNI]
-        self.mock_client_auth.get_chall_pref.return_value = [
+        self.mock_cont_auth.get_chall_pref.return_value = [
             challenges.RecoveryToken]
 
-        self.mock_client_auth.perform.side_effect = gen_auth_resp
+        self.mock_cont_auth.perform.side_effect = gen_auth_resp
         self.mock_dv_auth.perform.side_effect = gen_auth_resp
 
         self.handler = AuthHandler(
-            self.mock_dv_auth, self.mock_client_auth, None)
+            self.mock_dv_auth, self.mock_cont_auth, None)
 
         logging.disable(logging.CRITICAL)
 
@@ -78,7 +78,7 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertEqual(len(self.handler.responses[dom]), 1)
 
         # Test if statement for dv_auth perform
-        self.assertEqual(self.mock_client_auth.perform.call_count, 1)
+        self.assertEqual(self.mock_cont_auth.perform.call_count, 1)
         self.assertEqual(self.mock_dv_auth.perform.call_count, 0)
 
         self.assertEqual("RecoveryToken0", self.handler.responses[dom][0])
@@ -106,7 +106,7 @@ class SatisfyChallengesTest(unittest.TestCase):
         # Each message contains 1 auth, 0 client
 
         # Test proper call count for methods
-        self.assertEqual(self.mock_client_auth.perform.call_count, 0)
+        self.assertEqual(self.mock_cont_auth.perform.call_count, 0)
         self.assertEqual(self.mock_dv_auth.perform.call_count, 1)
 
         for i in xrange(5):
@@ -141,7 +141,7 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertEqual(len(self.handler.client_c), 1)
 
         # Test if statement for client_auth perform
-        self.assertEqual(self.mock_client_auth.perform.call_count, 0)
+        self.assertEqual(self.mock_cont_auth.perform.call_count, 0)
         self.assertEqual(self.mock_dv_auth.perform.call_count, 1)
 
         self.assertEqual(
@@ -309,11 +309,11 @@ class SatisfyChallengesTest(unittest.TestCase):
 
         # Verify cleanup is actually run correctly
         self.assertEqual(self.mock_dv_auth.cleanup.call_count, 2)
-        self.assertEqual(self.mock_client_auth.cleanup.call_count, 2)
+        self.assertEqual(self.mock_cont_auth.cleanup.call_count, 2)
 
 
         dv_cleanup_args = self.mock_dv_auth.cleanup.call_args_list
-        client_cleanup_args = self.mock_client_auth.cleanup.call_args_list
+        client_cleanup_args = self.mock_cont_auth.cleanup.call_args_list
 
         # Check DV cleanup
         for i in xrange(2):
@@ -346,7 +346,7 @@ class GetAuthorizationsTest(unittest.TestCase):
         from letsencrypt.client.auth_handler import AuthHandler
 
         self.mock_dv_auth = mock.MagicMock(name="ApacheConfigurator")
-        self.mock_client_auth = mock.MagicMock(name="ClientAuthenticator")
+        self.mock_cont_auth = mock.MagicMock(name="ContinuityAuthenticator")
 
         self.mock_sat_chall = mock.MagicMock(name="_satisfy_challenges")
         self.mock_acme_auth = mock.MagicMock(name="acme_authorization")
@@ -354,7 +354,7 @@ class GetAuthorizationsTest(unittest.TestCase):
         self.iteration = 0
 
         self.handler = AuthHandler(
-            self.mock_dv_auth, self.mock_client_auth, None)
+            self.mock_dv_auth, self.mock_cont_auth, None)
 
         self.handler._satisfy_challenges = self.mock_sat_chall
         self.handler.acme_authorization = self.mock_acme_auth

--- a/letsencrypt/client/tests/auth_handler_test.py
+++ b/letsencrypt/client/tests/auth_handler_test.py
@@ -61,9 +61,9 @@ class SatisfyChallengesTest(unittest.TestCase):
 
         self.assertEqual("DVSNI0", self.handler.responses[dom][0])
         self.assertEqual(len(self.handler.dv_c), 1)
-        self.assertEqual(len(self.handler.client_c), 1)
+        self.assertEqual(len(self.handler.cont_c), 1)
         self.assertEqual(len(self.handler.dv_c[dom]), 1)
-        self.assertEqual(len(self.handler.client_c[dom]), 0)
+        self.assertEqual(len(self.handler.cont_c[dom]), 0)
 
     def test_name1_rectok1(self):
         dom = "0"
@@ -84,10 +84,10 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertEqual("RecoveryToken0", self.handler.responses[dom][0])
         # Assert 1 domain
         self.assertEqual(len(self.handler.dv_c), 1)
-        self.assertEqual(len(self.handler.client_c), 1)
+        self.assertEqual(len(self.handler.cont_c), 1)
         # Assert 1 auth challenge, 0 dv
         self.assertEqual(len(self.handler.dv_c[dom]), 0)
-        self.assertEqual(len(self.handler.client_c[dom]), 1)
+        self.assertEqual(len(self.handler.cont_c[dom]), 1)
 
     def test_name5_dvsni5(self):
         for i in xrange(5):
@@ -102,7 +102,7 @@ class SatisfyChallengesTest(unittest.TestCase):
 
         self.assertEqual(len(self.handler.responses), 5)
         self.assertEqual(len(self.handler.dv_c), 5)
-        self.assertEqual(len(self.handler.client_c), 5)
+        self.assertEqual(len(self.handler.cont_c), 5)
         # Each message contains 1 auth, 0 client
 
         # Test proper call count for methods
@@ -114,7 +114,7 @@ class SatisfyChallengesTest(unittest.TestCase):
             self.assertEqual(len(self.handler.responses[dom]), 1)
             self.assertEqual(self.handler.responses[dom][0], "DVSNI%d" % i)
             self.assertEqual(len(self.handler.dv_c[dom]), 1)
-            self.assertEqual(len(self.handler.client_c[dom]), 0)
+            self.assertEqual(len(self.handler.cont_c[dom]), 0)
             self.assertTrue(isinstance(self.handler.dv_c[dom][0].achall,
                                        achallenges.DVSNI))
 
@@ -138,9 +138,9 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertEqual(len(self.handler.responses[dom]),
                          len(acme_util.DV_CHALLENGES))
         self.assertEqual(len(self.handler.dv_c), 1)
-        self.assertEqual(len(self.handler.client_c), 1)
+        self.assertEqual(len(self.handler.cont_c), 1)
 
-        # Test if statement for client_auth perform
+        # Test if statement for cont_auth perform
         self.assertEqual(self.mock_cont_auth.perform.call_count, 0)
         self.assertEqual(self.mock_dv_auth.perform.call_count, 1)
 
@@ -149,7 +149,7 @@ class SatisfyChallengesTest(unittest.TestCase):
             self._get_exp_response(dom, path, acme_util.DV_CHALLENGES))
 
         self.assertEqual(len(self.handler.dv_c[dom]), 1)
-        self.assertEqual(len(self.handler.client_c[dom]), 0)
+        self.assertEqual(len(self.handler.cont_c[dom]), 0)
         self.assertTrue(isinstance(self.handler.dv_c[dom][0].achall,
                                    achallenges.SimpleHTTPS))
 
@@ -175,16 +175,16 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertEqual(
             len(self.handler.responses[dom]), len(acme_util.CHALLENGES))
         self.assertEqual(len(self.handler.dv_c), 1)
-        self.assertEqual(len(self.handler.client_c), 1)
+        self.assertEqual(len(self.handler.cont_c), 1)
         self.assertEqual(len(self.handler.dv_c[dom]), 1)
-        self.assertEqual(len(self.handler.client_c[dom]), 1)
+        self.assertEqual(len(self.handler.cont_c[dom]), 1)
 
         self.assertEqual(
             self.handler.responses[dom],
             self._get_exp_response(dom, path, acme_util.CHALLENGES))
         self.assertTrue(isinstance(self.handler.dv_c[dom][0].achall,
                                    achallenges.SimpleHTTPS))
-        self.assertTrue(isinstance(self.handler.client_c[dom][0].achall,
+        self.assertTrue(isinstance(self.handler.cont_c[dom][0].achall,
                                    achallenges.RecoveryToken))
 
     @mock.patch("letsencrypt.client.auth_handler.gen_challenge_path")
@@ -209,7 +209,7 @@ class SatisfyChallengesTest(unittest.TestCase):
             self.assertEqual(
                 len(self.handler.responses[str(i)]), len(acme_util.CHALLENGES))
         self.assertEqual(len(self.handler.dv_c), 5)
-        self.assertEqual(len(self.handler.client_c), 5)
+        self.assertEqual(len(self.handler.cont_c), 5)
 
         for i in xrange(5):
             dom = str(i)
@@ -217,11 +217,11 @@ class SatisfyChallengesTest(unittest.TestCase):
                 self.handler.responses[dom],
                 self._get_exp_response(dom, path, acme_util.CHALLENGES))
             self.assertEqual(len(self.handler.dv_c[dom]), 1)
-            self.assertEqual(len(self.handler.client_c[dom]), 1)
+            self.assertEqual(len(self.handler.cont_c[dom]), 1)
 
             self.assertTrue(isinstance(self.handler.dv_c[dom][0].achall,
                                        achallenges.DVSNI))
-            self.assertTrue(isinstance(self.handler.client_c[dom][0].achall,
+            self.assertTrue(isinstance(self.handler.cont_c[dom][0].achall,
                                        achallenges.RecoveryContact))
 
     @mock.patch("letsencrypt.client.auth_handler.gen_challenge_path")
@@ -255,7 +255,7 @@ class SatisfyChallengesTest(unittest.TestCase):
 
         self.assertEqual(len(self.handler.responses), 5)
         self.assertEqual(len(self.handler.dv_c), 5)
-        self.assertEqual(len(self.handler.client_c), 5)
+        self.assertEqual(len(self.handler.cont_c), 5)
 
         for i in xrange(5):
             dom = str(i)
@@ -263,7 +263,7 @@ class SatisfyChallengesTest(unittest.TestCase):
             self.assertEqual(self.handler.responses[dom], resp)
             self.assertEqual(len(self.handler.dv_c[dom]), 1)
             self.assertEqual(
-                len(self.handler.client_c[dom]), len(chosen_chall[i]) - 1)
+                len(self.handler.cont_c[dom]), len(chosen_chall[i]) - 1)
 
         self.assertTrue(isinstance(
             self.handler.dv_c["0"][0].achall, achallenges.DNS))
@@ -276,10 +276,10 @@ class SatisfyChallengesTest(unittest.TestCase):
         self.assertTrue(isinstance(
             self.handler.dv_c["4"][0].achall, achallenges.DNS))
 
-        self.assertTrue(isinstance(self.handler.client_c["2"][0].achall,
+        self.assertTrue(isinstance(self.handler.cont_c["2"][0].achall,
                                    achallenges.ProofOfPossession))
         self.assertTrue(isinstance(
-            self.handler.client_c["4"][0].achall, achallenges.RecoveryToken))
+            self.handler.cont_c["4"][0].achall, achallenges.RecoveryToken))
 
     @mock.patch("letsencrypt.client.auth_handler.gen_challenge_path")
     def test_perform_exception_cleanup(self, mock_chall_path):
@@ -313,7 +313,7 @@ class SatisfyChallengesTest(unittest.TestCase):
 
 
         dv_cleanup_args = self.mock_dv_auth.cleanup.call_args_list
-        client_cleanup_args = self.mock_cont_auth.cleanup.call_args_list
+        cont_cleanup_args = self.mock_cont_auth.cleanup.call_args_list
 
         # Check DV cleanup
         for i in xrange(2):
@@ -325,10 +325,10 @@ class SatisfyChallengesTest(unittest.TestCase):
 
         # Check Auth cleanup
         for i in xrange(2):
-            client_chall_list = client_cleanup_args[i][0][0]
-            self.assertEqual(len(client_chall_list), 1)
+            cont_chall_list = cont_cleanup_args[i][0][0]
+            self.assertEqual(len(cont_chall_list), 1)
             self.assertTrue(
-                isinstance(client_chall_list[0], achallenges.ProofOfPossession))
+                isinstance(cont_chall_list[0], achallenges.ProofOfPossession))
 
 
     def _get_exp_response(self, domain, path, challs):
@@ -388,7 +388,7 @@ class GetAuthorizationsTest(unittest.TestCase):
             # Assignment was > 80 char...
             dv_c, c_c = self.handler._challenge_factory(dom, [0])
 
-            self.handler.dv_c[dom], self.handler.client_c[dom] = dv_c, c_c
+            self.handler.dv_c[dom], self.handler.cont_c[dom] = dv_c, c_c
 
     def test_progress_failure(self):
         self.handler.add_chall_msg(
@@ -414,7 +414,7 @@ class GetAuthorizationsTest(unittest.TestCase):
             self.handler.msgs[dom].challenges)
         dv_c, c_c = self.handler._challenge_factory(
             dom, self.handler.paths[dom])
-        self.handler.dv_c[dom], self.handler.client_c[dom] = dv_c, c_c
+        self.handler.dv_c[dom], self.handler.cont_c[dom] = dv_c, c_c
 
     def test_incremental_progress(self):
         for dom, challs in [("0", acme_util.CHALLENGES),
@@ -444,9 +444,9 @@ class GetAuthorizationsTest(unittest.TestCase):
             self.handler.paths["1"] = [2]
             # This is probably overkill... but set it anyway
             dv_c, c_c = self.handler._challenge_factory("0", [1, 3])
-            self.handler.dv_c["0"], self.handler.client_c["0"] = dv_c, c_c
+            self.handler.dv_c["0"], self.handler.cont_c["0"] = dv_c, c_c
             dv_c, c_c = self.handler._challenge_factory("1", [2])
-            self.handler.dv_c["1"], self.handler.client_c["1"] = dv_c, c_c
+            self.handler.dv_c["1"], self.handler.cont_c["1"] = dv_c, c_c
 
             self.iteration += 1
 
@@ -555,7 +555,7 @@ class GenChallengePathTest(unittest.TestCase):
          # dumb_path() trivial test
         self.assertTrue(self._call(challs, prefs, None))
 
-    def test_full_client_server(self):
+    def test_full_cont_server(self):
         challs = (acme_util.RECOVERY_TOKEN,
                   acme_util.RECOVERY_CONTACT,
                   acme_util.POP,

--- a/letsencrypt/client/tests/continuity_auth_test.py
+++ b/letsencrypt/client/tests/continuity_auth_test.py
@@ -1,4 +1,4 @@
-"""Test the ClientAuthenticator dispatcher."""
+"""Test the ContinuityAuthenticator dispatcher."""
 import unittest
 
 import mock
@@ -13,9 +13,9 @@ class PerformTest(unittest.TestCase):
     """Test client perform function."""
 
     def setUp(self):
-        from letsencrypt.client.client_authenticator import ClientAuthenticator
+        from letsencrypt.client.continuity_auth import ContinuityAuthenticator
 
-        self.auth = ClientAuthenticator(
+        self.auth = ContinuityAuthenticator(
             mock.MagicMock(server="demo_server.org"))
         self.auth.rec_token.perform = mock.MagicMock(
             name="rec_token_perform", side_effect=gen_client_resp)
@@ -38,7 +38,7 @@ class PerformTest(unittest.TestCase):
 
     def test_unexpected(self):
         self.assertRaises(
-            errors.LetsEncryptClientAuthError, self.auth.perform, [
+            errors.LetsEncryptContAuthError, self.auth.perform, [
                 achallenges.DVSNI(chall=None, domain="0", key="invalid_key")])
 
     def test_chall_pref(self):
@@ -50,9 +50,9 @@ class CleanupTest(unittest.TestCase):
     """Test the Authenticator cleanup function."""
 
     def setUp(self):
-        from letsencrypt.client.client_authenticator import ClientAuthenticator
+        from letsencrypt.client.continuity_auth import ContinuityAuthenticator
 
-        self.auth = ClientAuthenticator(
+        self.auth = ContinuityAuthenticator(
             mock.MagicMock(server="demo_server.org"))
         self.mock_cleanup = mock.MagicMock(name="rec_token_cleanup")
         self.auth.rec_token.cleanup = self.mock_cleanup
@@ -70,7 +70,7 @@ class CleanupTest(unittest.TestCase):
         token = achallenges.RecoveryToken(chall=None, domain="0")
         unexpected = achallenges.DVSNI(chall=None, domain="0", key="dummy_key")
 
-        self.assertRaises(errors.LetsEncryptClientAuthError,
+        self.assertRaises(errors.LetsEncryptContAuthError,
                           self.auth.cleanup, [token, unexpected])
 
 


### PR DESCRIPTION
Building off of #303.... this goes through and changes all references to client_challenges or client_authenticator to continuity_challengs/authenticator (I hope).  This change was made off of a comment at the hackathon, but was a bit painful to implement.

If this interferes with your work, @garrettr, it can be held off (it changes the naming of variables within the auth_handler)