### PR TITLE
Revert to ChallengeResource/ChallengeBody/Challenge triplet

### DIFF
--- a/letsencrypt/acme/messages2.py
+++ b/letsencrypt/acme/messages2.py
@@ -167,6 +167,9 @@ class ChallengeBody(ResourceBody):
        such as ``challb`` to distinguish instanced of this class from
        ``achall``.
 
+    :ivar letsencrypt.acme.challenges.Challenge: Wrapped challenge.
+        Conveniently, all challenge fields are proxied, i.e. you can
+        call ``challb.x`` to get ``challb.chall.x`` contents.
     :ivar letsencrypt.acme.messages2.Status status:
     :ivar datetime.datetime validated:
 
@@ -186,6 +189,9 @@ class ChallengeBody(ResourceBody):
         jobj_fields = super(ChallengeBody, cls).fields_from_json(jobj)
         jobj_fields['chall'] = challenges.Challenge.from_json(jobj)
         return jobj_fields
+
+    def __getattr__(self, name):
+        return getattr(self.chall, name)
 
 
 class AuthorizationResource(Resource):

--- a/letsencrypt/acme/messages2_test.py
+++ b/letsencrypt/acme/messages2_test.py
@@ -103,6 +103,9 @@ class ChallengeBodyTest(unittest.TestCase):
         from letsencrypt.acme.messages2 import ChallengeBody
         self.assertEqual(self.challb, ChallengeBody.from_json(self.jobj_from))
 
+    def test_getattr_proxy(self):
+        self.assertEqual('foo', self.challb.token)
+
 
 class AuthorizationTest(unittest.TestCase):
     """Tests for letsencrypt.acme.messages2.Authorization."""

--- a/letsencrypt/client/achallenges.py
+++ b/letsencrypt/client/achallenges.py
@@ -26,10 +26,13 @@ from letsencrypt.client import crypto_util
 class AnnotatedChallenge(jose_util.ImmutableMap):
     """Client annotated challenge.
 
-    Wraps around :class:`~letsencrypt.acme.challenges.Challenge` and
-    annotates with data useful for the client.
+    Wraps around server provided challenge and annotates with data
+    useful for the client.
+
+    :ivar chall: Wrapped `~.ChallengeBody` (or just `~.challenges.Challenge`).
 
     """
+    __slots__ = ('chall',)
     acme_type = NotImplemented
 
     def __getattr__(self, name):

--- a/letsencrypt/client/achallenges.py
+++ b/letsencrypt/client/achallenges.py
@@ -1,17 +1,20 @@
 """Client annotated ACME challenges.
 
 Please use names such as ``achall`` to distiguish from variables "of type"
-:class:`letsencrypt.acme.challenges.Challenge` (denoted by ``chall``)::
+:class:`letsencrypt.acme.challenges.Challenge` (denoted by ``chall``)
+and :class:`.ChallengeBody` (denoted by ``challb``)::
 
   from letsencrypt.acme import challenges
+  from letsencrypt.acme import messages2
   from letsencrypt.client import achallenges
 
   chall = challenges.DNS(token='foo')
-  achall = achallenges.DNS(chall=chall, domain='example.com')
+  challb = messages2.ChallengeBody(chall=chall)
+  achall = achallenges.DNS(chall=challb, domain='example.com')
 
 Note, that all annotated challenges act as a proxy objects::
 
-  achall.token == chall.token
+  achall.token == challb.token
 
 """
 from letsencrypt.acme import challenges
@@ -29,19 +32,19 @@ class AnnotatedChallenge(jose_util.ImmutableMap):
     Wraps around server provided challenge and annotates with data
     useful for the client.
 
-    :ivar chall: Wrapped `~.ChallengeBody` (or just `~.challenges.Challenge`).
+    :ivar challb: Wrapped `~.ChallengeBody`.
 
     """
-    __slots__ = ('chall',)
+    __slots__ = ('challb',)
     acme_type = NotImplemented
 
     def __getattr__(self, name):
-        return getattr(self.chall, name)
+        return getattr(self.challb, name)
 
 
 class DVSNI(AnnotatedChallenge):
     """Client annotated "dvsni" ACME challenge."""
-    __slots__ = ('chall', 'domain', 'key')
+    __slots__ = ('challb', 'domain', 'key')
     acme_type = challenges.DVSNI
 
     def gen_cert_and_response(self, s=None):  # pylint: disable=invalid-name
@@ -55,35 +58,35 @@ class DVSNI(AnnotatedChallenge):
         """
         response = challenges.DVSNIResponse(s=s)
         cert_pem = crypto_util.make_ss_cert(self.key.pem, [
-            self.nonce_domain, self.domain, response.z_domain(self.chall)])
+            self.nonce_domain, self.domain, response.z_domain(self.challb)])
         return cert_pem, response
 
 
 class SimpleHTTPS(AnnotatedChallenge):
     """Client annotated "simpleHttps" ACME challenge."""
-    __slots__ = ('chall', 'domain', 'key')
+    __slots__ = ('challb', 'domain', 'key')
     acme_type = challenges.SimpleHTTPS
 
 
 class DNS(AnnotatedChallenge):
     """Client annotated "dns" ACME challenge."""
-    __slots__ = ('chall', 'domain')
+    __slots__ = ('challb', 'domain')
     acme_type = challenges.DNS
 
 
 class RecoveryContact(AnnotatedChallenge):
     """Client annotated "recoveryContact" ACME challenge."""
-    __slots__ = ('chall', 'domain')
+    __slots__ = ('challb', 'domain')
     acme_type = challenges.RecoveryContact
 
 
 class RecoveryToken(AnnotatedChallenge):
     """Client annotated "recoveryToken" ACME challenge."""
-    __slots__ = ('chall', 'domain')
+    __slots__ = ('challb', 'domain')
     acme_type = challenges.RecoveryToken
 
 
 class ProofOfPossession(AnnotatedChallenge):
     """Client annotated "proofOfPossession" ACME challenge."""
-    __slots__ = ('chall', 'domain')
+    __slots__ = ('challb', 'domain')
     acme_type = challenges.ProofOfPossession

--- a/letsencrypt/client/network2.py
+++ b/letsencrypt/client/network2.py
@@ -224,7 +224,7 @@ class Network(object):
         :rtype: `.RegistrationResource`
 
         """
-        self.update_registration(
+        return self.update_registration(
             regr.update(body=regr.body.update(agreement=regr.terms_of_service)))
 
     def _authzr_from_response(self, response, identifier,


### PR DESCRIPTION
Fixes "jose.Field inheritance" problem mentioned in https://github.com/letsencrypt/lets-encrypt-preview/commit/37620ebe39d7e5286cd920ab235e3894086be352#commitcomment-10703875

```
(venv)root@le:~/lets-encrypt-preview# letsencrypt -ted foo.com
INFO:root:Generating key (2048 bits): /etc/letsencrypt/keys/0040_key-letsencrypt.pem
INFO:root:Performing the following challenges:
INFO:root:  DVSNI challenge for foo.com.
INFO:root:Waiting for verification...
INFO:root:Cleaning up challenges
INFO:root:Cleaning up challenges
INFO:root:Creating CSR: /etc/letsencrypt/certs/0003_csr-letsencrypt.pem
INFO:root:Server issued certificate; certificate written to /etc/letsencrypt/certs/cert-letsencrypt.pem
```

I didn't want to mess too much with `client/` not to interfere with your work, @jdkasten, so I leave unittests update for you :)