### PR TITLE
Don't use sudo in apache plugin

### DIFF
--- a/letsencrypt/client/plugins/apache/configurator.py
+++ b/letsencrypt/client/plugins/apache/configurator.py
@@ -908,7 +908,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         """
         try:
             proc = subprocess.Popen(
-                ["sudo", self.config.apache_ctl, "configtest"], # TODO: sudo?
+                [self.config.apache_ctl, "configtest"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             stdout, stderr = proc.communicate()
@@ -1046,7 +1046,7 @@ def enable_mod(mod_name, apache_init_script, apache_enmod):
     try:
         # Use check_output so the command will finish before reloading
         # TODO: a2enmod is debian specific...
-        subprocess.check_call(["sudo", apache_enmod, mod_name],  # TODO: sudo?
+        subprocess.check_call([apache_enmod, mod_name],
                               stdout=open("/dev/null", "w"),
                               stderr=open("/dev/null", "w"))
         apache_restart(apache_init_script)


### PR DESCRIPTION
CLI already requires to be run as root, so there is no point in proxying commands through sudo (sudo might not be even available on the target system)