### PR TITLE
dvsni support for nginx

### DIFF
--- a/letsencrypt/client/plugins/nginx/configurator.py
+++ b/letsencrypt/client/plugins/nginx/configurator.py
@@ -545,11 +545,18 @@ def nginx_restart(nginx_ctl):
         stdout, stderr = proc.communicate()
 
         if proc.returncode != 0:
-            # Enter recovery routine...
-            logging.error("Nginx Restart Failed!")
-            logging.error(stdout)
-            logging.error(stderr)
-            return False
+            # Maybe Nginx isn't running
+            nginx_proc = subprocess.Popen([nginx_ctl],
+                                          stdout=subprocess.PIPE,
+                                          stderr=subprocess.PIPE)
+            stdout, stderr = nginx_proc.communicate()
+
+            if nginx_proc.returncode != 0:
+                # Enter recovery routine...
+                logging.error("Nginx Restart Failed!")
+                logging.error(stdout)
+                logging.error(stderr)
+                return False
 
     except (OSError, ValueError):
         logging.fatal(

--- a/letsencrypt/client/plugins/nginx/configurator.py
+++ b/letsencrypt/client/plugins/nginx/configurator.py
@@ -399,10 +399,11 @@ class NginxConfigurator(object):
 
         nginx_version = tuple([int(i) for i in version_matches[0].split(".")])
 
-        # nginx < 0.8.21 doesn't use default_server
-        if nginx_version < (0, 8, 21):
+        # nginx < 0.8.48 uses machine hostname as default server_name instead of
+        # the empty string
+        if nginx_version < (0, 8, 48):
             raise errors.LetsEncryptConfiguratorError(
-                "Nginx version must be 0.8.21+")
+                "Nginx version must be 0.8.48+")
 
         return nginx_version
 

--- a/letsencrypt/client/plugins/nginx/configurator.py
+++ b/letsencrypt/client/plugins/nginx/configurator.py
@@ -159,8 +159,12 @@ class NginxConfigurator(object):
 
         matches = self._get_ranked_matches(target_name)
         if not matches:
-            # No matches at all :'(
-            pass
+            # No matches. Create a new vhost with this name in nginx.conf.
+            filep = self.parser.loc["root"]
+            new_block = [['server'], [['server_name', target_name]]]
+            self.parser.add_http_directives(filep, new_block)
+            vhost = obj.VirtualHost(filep, set([]), False, True,
+                                    set([target_name]), list(new_block[1]))
         elif matches[0]['rank'] in xrange(2, 6):
             # Wildcard match - need to find the longest one
             rank = matches[0]['rank']

--- a/letsencrypt/client/plugins/nginx/dvsni.py
+++ b/letsencrypt/client/plugins/nginx/dvsni.py
@@ -52,9 +52,8 @@ class NginxDvsni(ApacheDvsni):
             vhost = self.configurator.choose_vhost(achall.domain)
             if vhost is None:
                 logging.error(
-                    "No nginx vhost exists with server_name or alias of: %s",
+                    "No nginx vhost exists with server_name matching: %s",
                     achall.domain)
-                logging.error("No default 443 nginx vhost exists")
                 logging.error("Please specify server_names in the Nginx config")
                 return None
 

--- a/letsencrypt/client/plugins/nginx/obj.py
+++ b/letsencrypt/client/plugins/nginx/obj.py
@@ -97,7 +97,7 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
     :ivar set addrs: Virtual Host addresses (:class:`set` of :class:`Addr`)
     :ivar set names: Server names/aliases of vhost
         (:class:`list` of :class:`str`)
-    :ivar array raw: The raw form of the parsed server block
+    :ivar list raw: The raw form of the parsed server block
 
     :ivar bool ssl: SSLEngine on in vhost
     :ivar bool enabled: Virtual host is enabled

--- a/letsencrypt/client/plugins/nginx/obj.py
+++ b/letsencrypt/client/plugins/nginx/obj.py
@@ -67,12 +67,20 @@ class Addr(ApacheAddr):
         return cls(host, port, ssl, default)
 
     def __str__(self):
+        parts = ''
         if self.tup[0] and self.tup[1]:
-            return "%s:%s" % self.tup
+            parts = "%s:%s" % self.tup
         elif self.tup[0]:
-            return self.tup[0]
+            parts = self.tup[0]
         else:
-            return self.tup[1]
+            parts = self.tup[1]
+
+        if self.default:
+            parts += ' default_server'
+        if self.ssl:
+            parts += ' ssl'
+
+        return parts
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/letsencrypt/client/plugins/nginx/parser.py
+++ b/letsencrypt/client/plugins/nginx/parser.py
@@ -166,7 +166,7 @@ class NginxParser(object):
             except IOError:
                 logging.warn("Could not open file: %s", item)
             except pyparsing.ParseException:
-                logging.warn("Could not parse file: %s", item)
+                logging.debug("Could not parse file: %s", item)
         return trees
 
     def _set_locations(self, ssl_options):

--- a/letsencrypt/client/plugins/nginx/parser.py
+++ b/letsencrypt/client/plugins/nginx/parser.py
@@ -253,7 +253,7 @@ class NginxParser(object):
 
     def add_server_directives(self, filename, names, directives,
                               replace=False):
-        """Add or replace directives in server blocks identified by server_name.
+        """Add or replace directives in the first server block with names.
 
         ..note :: If replace is True, this raises a misconfiguration error
         if the directive does not already exist.
@@ -267,14 +267,20 @@ class NginxParser(object):
         :param bool replace: Whether to only replace existing directives
 
         """
-        if replace:
-            _do_for_subarray(self.parsed[filename],
-                             lambda x: self._has_server_names(x, names),
-                             lambda x: _replace_directives(x, directives))
-        else:
-            _do_for_subarray(self.parsed[filename],
-                             lambda x: self._has_server_names(x, names),
-                             lambda x: x.extend(directives))
+        _do_for_subarray(self.parsed[filename],
+                         lambda x: self._has_server_names(x, names),
+                         lambda x: _add_directives(x, directives, replace))
+
+    def add_http_directives(self, filename, directives):
+        """Adds directives to the first encountered HTTP block in filename.
+
+        :param str filename: The absolute filename of the config file
+        :param list directives: The directives to add
+
+        """
+        _do_for_subarray(self.parsed[filename],
+                         lambda x: x[0] == ['http'],
+                         lambda x: _add_directives(x[1], [directives], False))
 
     def get_all_certs_keys(self):
         """Gets all certs and keys in the nginx config.
@@ -463,24 +469,28 @@ def _parse_server(server):
     return parsed_server
 
 
-def _replace_directives(block, directives):
-    """Replaces directives in a block. If the directive doesn't exist in
+def _add_directives(block, directives, replace=False):
+    """Adds or replaces directives in a block. If the directive doesn't exist in
     the entry already, raises a misconfiguration error.
 
     ..todo :: Find directives that are in included files.
 
     :param list block: The block to replace in
     :param list directives: The new directives.
+
     """
-    for directive in directives:
-        changed = False
-        if len(directive) == 0:
-            continue
-        for index, line in enumerate(block):
-            if len(line) > 0 and line[0] == directive[0]:
-                block[index] = directive
-                changed = True
-        if not changed:
-            raise errors.LetsEncryptMisconfigurationError(
-                'LetsEncrypt expected directive for %s in the Nginx config '
-                'but did not find it.' % directive[0])
+    if replace:
+        for directive in directives:
+            changed = False
+            if len(directive) == 0:
+                continue
+            for index, line in enumerate(block):
+                if len(line) > 0 and line[0] == directive[0]:
+                    block[index] = directive
+                    changed = True
+            if not changed:
+                raise errors.LetsEncryptMisconfigurationError(
+                    'LetsEncrypt expected directive for %s in the Nginx '
+                    'config but did not find it.' % directive[0])
+    else:
+        block.extend(directives)

--- a/letsencrypt/client/plugins/nginx/parser.py
+++ b/letsencrypt/client/plugins/nginx/parser.py
@@ -33,6 +33,7 @@ class NginxParser(object):
         """Loads Nginx files into a parsed tree.
 
         """
+        self.parsed = {}
         self._parse_recursively(self.loc["root"])
 
     def _parse_recursively(self, filepath):
@@ -252,8 +253,9 @@ class NginxParser(object):
 
     def add_server_directives(self, filename, names, directives,
                               replace=False):
-        """Add or replace directives in server blocks whose server_name set
-        is 'names'. If replace is True, this raises a misconfiguration error
+        """Add or replace directives in server blocks identified by server_name.
+
+        ..note :: If replace is True, this raises a misconfiguration error
         if the directive does not already exist.
 
         ..todo :: Doesn't match server blocks whose server_name directives are

--- a/letsencrypt/client/plugins/nginx/tests/configurator_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/configurator_test.py
@@ -91,7 +91,7 @@ class NginxConfiguratorTest(util.NginxTest):
             self.assertEqual(results[name],
                              self.config.choose_vhost(name).names)
         for name in bad_results:
-            self.assertEqual(None, self.config.choose_vhost(name))
+            self.assertEqual(set([name]), self.config.choose_vhost(name).names)
 
     def test_more_info(self):
         self.assertTrue('nginx.conf' in self.config.more_info())

--- a/letsencrypt/client/plugins/nginx/tests/configurator_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/configurator_test.py
@@ -261,6 +261,20 @@ class NginxConfiguratorTest(util.NginxTest):
 
     @mock.patch("letsencrypt.client.plugins.nginx.configurator."
                 "subprocess.Popen")
+    def test_nginx_restart_fail(self, mock_popen):
+        mocked = mock_popen()
+        mocked.communicate.return_value = ('', '')
+        mocked.returncode = 1
+        self.assertFalse(self.config.restart())
+
+    @mock.patch("letsencrypt.client.plugins.nginx.configurator."
+                "subprocess.Popen")
+    def test_no_nginx_start(self, mock_popen):
+        mock_popen.side_effect = OSError("Can't find program")
+        self.assertRaises(SystemExit, self.config.restart)
+
+    @mock.patch("letsencrypt.client.plugins.nginx.configurator."
+                "subprocess.Popen")
     def test_config_test(self, mock_popen):
         mocked = mock_popen()
         mocked.communicate.return_value = ('', '')

--- a/letsencrypt/client/plugins/nginx/tests/dvsni_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/dvsni_test.py
@@ -79,7 +79,7 @@ class DvsniPerformTest(util.NginxTest):
     def test_perform(self, mock_save):
         self.sni.add_chall(self.achalls[1])
         responses = self.sni.perform()
-        self.assertEqual(None, responses)
+        self.assertTrue(responses is None)
         self.assertEqual(mock_save.call_count, 1)
 
     def test_perform0(self):
@@ -153,10 +153,7 @@ class DvsniPerformTest(util.NginxTest):
         self.assertTrue(['include', self.sni.challenge_conf] in http[1])
 
         vhosts = self.sni.configurator.parser.get_vhosts()
-        vhs = []
-        for vhost in vhosts:
-            if vhost.filep == self.sni.challenge_conf:
-                vhs.append(vhost)
+        vhs = [vh for vh in vhosts if vh.filep == self.sni.challenge_conf]
 
         for vhost in vhs:
             if vhost.addrs == set(v_addr1):

--- a/letsencrypt/client/plugins/nginx/tests/obj_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/obj_test.py
@@ -49,11 +49,11 @@ class AddrTest(unittest.TestCase):
 
     def test_str(self):
         self.assertEqual(str(self.addr1), "192.168.1.1")
-        self.assertEqual(str(self.addr2), "192.168.1.1:*")
+        self.assertEqual(str(self.addr2), "192.168.1.1:* ssl")
         self.assertEqual(str(self.addr3), "192.168.1.1:80")
-        self.assertEqual(str(self.addr4), "*:80")
+        self.assertEqual(str(self.addr4), "*:80 default_server ssl")
         self.assertEqual(str(self.addr5), "myhost")
-        self.assertEqual(str(self.addr6), "80")
+        self.assertEqual(str(self.addr6), "80 default_server")
 
     def test_eq(self):
         from letsencrypt.client.plugins.nginx.obj import Addr

--- a/letsencrypt/client/plugins/nginx/tests/parser_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/parser_test.py
@@ -140,6 +140,16 @@ class NginxParserTest(util.NginxTest):
                           ['foo', 'bar'],
                           ['ssl_certificate', '/etc/ssl/cert2.pem']])
 
+    def test_add_http_directives(self):
+        nparser = parser.NginxParser(self.config_path, self.ssl_options)
+        filep = nparser.abs_path('nginx.conf')
+        block = [['server'],
+                 [['listen', '80'],
+                  ['server_name', 'localhost']]]
+        nparser.add_http_directives(filep, block)
+        self.assertEqual(nparser.parsed[filep][-1][0], ['http'])
+        self.assertEqual(nparser.parsed[filep][-1][1][-1], block)
+
     def test_replace_server_directives(self):
         nparser = parser.NginxParser(self.config_path, self.ssl_options)
         target = set(['.example.com', 'example.*'])


### PR DESCRIPTION
This adds DVSNI support for Nginx.

This doesn't seem to quite work yet - when I run this on an ubuntu server at letsencrypt.icann.wtf, I get the following mysterious error:

```
  File "./venv/bin/letsencrypt", line 9, in <module>
    load_entry_point('letsencrypt==0.1', 'console_scripts', 'letsencrypt')()
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/scripts/main.py", line 247, in main
    cert_file, chain_file = acme.obtain_certificate(doms)
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/client.py", line 126, in obtain_certificate
    authzr = self.auth_handler.get_authorizations(domains)
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/auth_handler.py", line 69, in get_authorizations
    domain, self.account.new_authzr_uri)
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/network2.py", line 297, in request_domain_challenges
    typ=messages2.IDENTIFIER_FQDN, value=domain), new_authz_uri)
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/network2.py", line 278, in request_challenges
    response = self._post(new_authzr_uri, self._wrap_in_jws(new_authz))
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/network2.py", line 143, in _post
    self._check_response(response, content_type=content_type)
  File "/home/yan/lets-encrypt-preview/venv/local/lib/python2.7/site-packages/letsencrypt-0.1-py2.7.egg/letsencrypt/client/network2.py", line 92, in _check_response
    raise messages2.Error.from_json(jobj)
letsencrypt.acme.messages2.Error
```