### PR TITLE
Separate keys

### DIFF
--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -99,9 +99,7 @@ class Client(object):
 
         :meth:`.register` must be called before :meth:`.obtain_certificate`
 
-        .. todo:: This function currently uses the account key for the cert.
-            This should be changed to an independent key once renewal is sorted
-            out.
+        .. todo:: This function does not currently handle csr correctly...
 
         :param set domains: domains to get a certificate
 
@@ -127,8 +125,10 @@ class Client(object):
 
         # Create CSR from names
         if csr is None:
+            cert_key = crypto_util.init_save_key(
+                self.config.rsa_key_size, self.config.key_dir)
             csr = crypto_util.init_save_csr(
-                self.account.key, domains, self.config.cert_dir)
+                cert_key, domains, self.config.cert_dir)
 
         # Retrieve certificate
         certr = self.network.request_issuance(

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -107,8 +107,8 @@ class Client(object):
             this CSR can be different than self.authkey
         :type csr: :class:`CSR`
 
-        :returns: cert_file, chain_file (paths to respective files)
-        :rtype: `tuple` of `str`
+        :returns: cert_key, cert_path, chain_path
+        :rtype: `tuple` of (:class:`letsencrypt.client.le_util.Key`, str, str)
 
         """
         if self.auth_handler is None:
@@ -136,13 +136,13 @@ class Client(object):
             authzr)
 
         # Save Certificate
-        cert_file, chain_file = self.save_certificate(
+        cert_path, chain_path = self.save_certificate(
             certr, self.config.cert_path, self.config.chain_path)
 
         revoker.Revoker.store_cert_key(
-            cert_file, self.account.key.file, self.config)
+            cert_path, self.account.key.file, self.config)
 
-        return cert_key, cert_file, chain_file
+        return cert_key, cert_path, chain_path
 
     def save_certificate(self, certr, cert_path, chain_path):
         # pylint: disable=no-self-use

--- a/letsencrypt/client/client.py
+++ b/letsencrypt/client/client.py
@@ -124,11 +124,10 @@ class Client(object):
         authzr = self.auth_handler.get_authorizations(domains)
 
         # Create CSR from names
-        if csr is None:
-            cert_key = crypto_util.init_save_key(
-                self.config.rsa_key_size, self.config.key_dir)
-            csr = crypto_util.init_save_csr(
-                cert_key, domains, self.config.cert_dir)
+        cert_key = crypto_util.init_save_key(
+            self.config.rsa_key_size, self.config.key_dir)
+        csr = crypto_util.init_save_csr(
+            cert_key, domains, self.config.cert_dir)
 
         # Retrieve certificate
         certr = self.network.request_issuance(
@@ -143,7 +142,7 @@ class Client(object):
         revoker.Revoker.store_cert_key(
             cert_file, self.account.key.file, self.config)
 
-        return cert_file, chain_file
+        return cert_key, cert_file, chain_file
 
     def save_certificate(self, certr, cert_path, chain_path):
         # pylint: disable=no-self-use

--- a/letsencrypt/scripts/main.py
+++ b/letsencrypt/scripts/main.py
@@ -244,9 +244,9 @@ def main():  # pylint: disable=too-many-branches, too-many-statements
                 acme.register()
             except errors.LetsEncryptClientError:
                 sys.exit(0)
-        cert_file, chain_file = acme.obtain_certificate(doms)
+        cert_key, cert_file, chain_file = acme.obtain_certificate(doms)
     if installer is not None and cert_file is not None:
-        acme.deploy_certificate(doms, acc.key, cert_file, chain_file)
+        acme.deploy_certificate(doms, cert_key, cert_file, chain_file)
     if installer is not None:
         acme.enhance_config(doms, args.redirect)
 


### PR DESCRIPTION
Quick fix to separate the certificate key from the account key.