### PR TITLE
Cover tests (fixes #402).

### DIFF
--- a/letsencrypt/acme/challenges_test.py
+++ b/letsencrypt/acme/challenges_test.py
@@ -455,4 +455,4 @@ class DNSResponseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/fields_test.py
+++ b/letsencrypt/acme/fields_test.py
@@ -33,3 +33,7 @@ class RFC3339FieldTest(unittest.TestCase):
         from letsencrypt.acme.fields import RFC3339Field
         self.assertRaises(
             jose.DeserializationError, RFC3339Field.default_decoder, '')
+
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/b64_test.py
+++ b/letsencrypt/acme/jose/b64_test.py
@@ -69,4 +69,4 @@ class B64DecodeTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/errors_test.py
+++ b/letsencrypt/acme/jose/errors_test.py
@@ -14,4 +14,4 @@ class UnrecognizedTypeErrorTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/interfaces_test.py
+++ b/letsencrypt/acme/jose/interfaces_test.py
@@ -112,4 +112,4 @@ class JSONDeSerializableTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/interfaces_test.py
+++ b/letsencrypt/acme/jose/interfaces_test.py
@@ -44,8 +44,7 @@ class JSONDeSerializableTest(unittest.TestCase):
 
             @classmethod
             def from_json(cls, jobj):
-                return cls(Basic.from_json(jobj.keys()[0]),
-                           Basic.from_json(jobj.values()[0]))
+                pass  # pragma: no cover
 
         self.basic1 = Basic('foo1')
         self.basic2 = Basic('foo2')

--- a/letsencrypt/acme/jose/json_util_test.py
+++ b/letsencrypt/acme/jose/json_util_test.py
@@ -45,10 +45,10 @@ class FieldTest(unittest.TestCase):
         class MockField(interfaces.JSONDeSerializable):
             # pylint: disable=missing-docstring
             def to_partial_json(self):
-                return 'foo'
+                return 'foo'  # pragma: no cover
             @classmethod
             def from_json(cls, jobj):
-                pass
+                pass  # pragma: no cover
         mock_field = MockField()
 
         from letsencrypt.acme.jose.json_util import Field

--- a/letsencrypt/acme/jose/json_util_test.py
+++ b/letsencrypt/acme/jose/json_util_test.py
@@ -294,4 +294,4 @@ class TypedJSONObjectWithFieldsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/jwa_test.py
+++ b/letsencrypt/acme/jose/jwa_test.py
@@ -26,10 +26,10 @@ class JWASignatureTest(unittest.TestCase):
             # pylint: disable=missing-docstring,too-few-public-methods
             # pylint: disable=abstract-class-not-used
             def sign(self, key, msg):
-                raise NotImplementedError()
+                raise NotImplementedError()  # pragma: no cover
 
             def verify(self, key, msg, sig):
-                raise NotImplementedError()
+                raise NotImplementedError()  # pragma: no cover
 
         # pylint: disable=invalid-name
         self.Sig1 = MockSig('Sig1')

--- a/letsencrypt/acme/jose/jwa_test.py
+++ b/letsencrypt/acme/jose/jwa_test.py
@@ -102,4 +102,4 @@ class JWARSTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/jwk_test.py
+++ b/letsencrypt/acme/jose/jwk_test.py
@@ -104,4 +104,4 @@ class JWKRSATest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/jws_test.py
+++ b/letsencrypt/acme/jose/jws_test.py
@@ -238,4 +238,4 @@ class CLITest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/jose/util_test.py
+++ b/letsencrypt/acme/jose/util_test.py
@@ -137,4 +137,4 @@ class frozendictTest(unittest.TestCase):  # pylint: disable=invalid-name
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/messages2_test.py
+++ b/letsencrypt/acme/messages2_test.py
@@ -246,4 +246,4 @@ class RevocationTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/messages_test.py
+++ b/letsencrypt/acme/messages_test.py
@@ -477,4 +477,4 @@ class StatusRequestTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/acme/other_test.py
+++ b/letsencrypt/acme/other_test.py
@@ -96,4 +96,4 @@ class SignatureTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/apache/tests/configurator_test.py
+++ b/letsencrypt/client/plugins/apache/tests/configurator_test.py
@@ -213,4 +213,4 @@ class TwoVhost80Test(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/apache/tests/dvsni_test.py
+++ b/letsencrypt/client/plugins/apache/tests/dvsni_test.py
@@ -173,4 +173,4 @@ class DvsniPerformTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/apache/tests/obj_test.py
+++ b/letsencrypt/client/plugins/apache/tests/obj_test.py
@@ -65,4 +65,4 @@ class VirtualHostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/apache/tests/parser_test.py
+++ b/letsencrypt/client/plugins/apache/tests/parser_test.py
@@ -126,4 +126,4 @@ class ApacheParserTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/common_test.py
+++ b/letsencrypt/client/plugins/common_test.py
@@ -58,4 +58,4 @@ class PluginTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/disco_test.py
+++ b/letsencrypt/client/plugins/disco_test.py
@@ -240,4 +240,4 @@ class PluginsRegistryTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/nginx/tests/configurator_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/configurator_test.py
@@ -268,4 +268,4 @@ class NginxConfiguratorTest(util.NginxTest):
         self.assertTrue(self.config.config_test())
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/nginx/tests/dvsni_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/dvsni_test.py
@@ -91,4 +91,4 @@ class DvsniPerformTest(util.NginxTest):
         self.assertEqual(mock_save.call_count, 1)
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/nginx/tests/nginxparser_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/nginxparser_test.py
@@ -105,4 +105,4 @@ class TestRawNginxParser(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/nginx/tests/obj_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/obj_test.py
@@ -102,4 +102,4 @@ class VirtualHostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/nginx/tests/parser_test.py
+++ b/letsencrypt/client/plugins/nginx/tests/parser_test.py
@@ -203,4 +203,4 @@ class NginxParserTest(util.NginxTest):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/plugins/standalone/tests/authenticator_test.py
+++ b/letsencrypt/client/plugins/standalone/tests/authenticator_test.py
@@ -606,4 +606,4 @@ class InitTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/account_test.py
+++ b/letsencrypt/client/tests/account_test.py
@@ -208,4 +208,4 @@ class SafeEmailTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/achallenges_test.py
+++ b/letsencrypt/client/tests/achallenges_test.py
@@ -44,4 +44,4 @@ class DVSNITest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/auth_handler_test.py
+++ b/letsencrypt/client/tests/auth_handler_test.py
@@ -458,4 +458,4 @@ def gen_path(required, challs):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/cli_test.py
+++ b/letsencrypt/client/tests/cli_test.py
@@ -32,4 +32,4 @@ class CLITest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/client_test.py
+++ b/letsencrypt/client/tests/client_test.py
@@ -27,11 +27,11 @@ class DetermineAccountTest(unittest.TestCase):
 
     @mock.patch("letsencrypt.client.client.account.Account.from_prompts")
     @mock.patch("letsencrypt.client.client.display_ops.choose_account")
-    def determine_account(self, mock_op, mock_prompt):
+    def test_determine_account(self, mock_op, mock_prompt):
         """Test determine account"""
         from letsencrypt.client import client
 
-        key = le_util.Key("file", "pem")
+        key = le_util.Key(tempfile.mkstemp()[1], "pem")
         test_acc = account.Account(self.config, key, "email1@gmail.com")
         mock_op.return_value = test_acc
 
@@ -82,4 +82,4 @@ class RollbackTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/configuration_test.py
+++ b/letsencrypt/client/tests/configuration_test.py
@@ -49,4 +49,4 @@ class NamespaceConfigTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/continuity_auth_test.py
+++ b/letsencrypt/client/tests/continuity_auth_test.py
@@ -80,4 +80,4 @@ def gen_client_resp(chall):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/crypto_util_test.py
+++ b/letsencrypt/client/tests/crypto_util_test.py
@@ -151,4 +151,4 @@ class MakeSSCertTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/display/enhancements_test.py
+++ b/letsencrypt/client/tests/display/enhancements_test.py
@@ -55,4 +55,4 @@ class RedirectTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/display/ops_test.py
+++ b/letsencrypt/client/tests/display/ops_test.py
@@ -318,4 +318,4 @@ class SuccessInstallationTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/display/revocation_test.py
+++ b/letsencrypt/client/tests/display/revocation_test.py
@@ -100,4 +100,4 @@ class ConfirmRevocationTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/display/util_test.py
+++ b/letsencrypt/client/tests/display/util_test.py
@@ -346,4 +346,4 @@ class PlaceParensTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/le_util_test.py
+++ b/letsencrypt/client/tests/le_util_test.py
@@ -123,4 +123,4 @@ class UniqueFileTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/log_test.py
+++ b/letsencrypt/client/tests/log_test.py
@@ -45,4 +45,4 @@ class DialogHandlerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/network2_test.py
+++ b/letsencrypt/client/tests/network2_test.py
@@ -479,4 +479,4 @@ class NetworkTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/recovery_token_test.py
+++ b/letsencrypt/client/tests/recovery_token_test.py
@@ -77,4 +77,4 @@ class RecoveryTokenTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/reverter_test.py
+++ b/letsencrypt/client/tests/reverter_test.py
@@ -445,4 +445,4 @@ def update_file(filename, string):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/letsencrypt/client/tests/revoker_test.py
+++ b/letsencrypt/client/tests/revoker_test.py
@@ -405,4 +405,4 @@ def create_revoker_certs():
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ dev = develop easy_install letsencrypt[dev,docs,testing]
 nocapture=1
 cover-package=letsencrypt
 cover-erase=1
+cover-tests=1

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ setenv =
 basepython = python2.7
 commands =
     pip install -e .[testing]
-    python setup.py nosetests --with-coverage --cover-min-percentage=89
+    python setup.py nosetests --with-coverage \
+           --cover-tests --cover-min-percentage=94
 
 [testenv:lint]
 # recent versions of pylint do not support Python 2.6 (#97, #187)


### PR DESCRIPTION
1. --cover-tests, to make sure every test is run, helped to find broken determine_account tests

2. fix determine_account test

3. unittest.main()  # pragma: no cover

4. bump coverage

coveralls.io always reported higher coverage, because it also looked at test files.