### PR TITLE
Plugins fixes (unhashable PluginEntryPoint, typo in examples)

### DIFF
--- a/examples/plugins/letsencrypt_example_plugins.py
+++ b/examples/plugins/letsencrypt_example_plugins.py
@@ -20,7 +20,7 @@ class Authenticator(common.Plugin):
     # "self" as first argument, e.g. def prepare(self)...
 
 
-class Installer(common.Plugins):
+class Installer(common.Plugin):
     """Example Installer."""
     zope.interface.implements(interfaces.IInstaller)
     zope.interface.classProvides(interfaces.IPluginFactory)

--- a/letsencrypt/plugins/disco.py
+++ b/letsencrypt/plugins/disco.py
@@ -215,8 +215,9 @@ class PluginsRegistry(collections.Mapping):
             return None
 
     def __repr__(self):
-        return "{0}({1!r})".format(
-            self.__class__.__name__, set(self._plugins.itervalues()))
+        return "{0}({1})".format(
+            self.__class__.__name__, ','.join(
+                repr(p_ep) for p_ep in self._plugins.itervalues()))
 
     def __str__(self):
         if not self._plugins:

--- a/letsencrypt/plugins/disco_test.py
+++ b/letsencrypt/plugins/disco_test.py
@@ -154,6 +154,7 @@ class PluginsRegistryTest(unittest.TestCase):
     def setUp(self):
         from letsencrypt.plugins.disco import PluginsRegistry
         self.plugin_ep = mock.MagicMock(name="mock")
+        self.plugin_ep.__hash__.side_effect = TypeError
         self.plugins = {"mock": self.plugin_ep}
         self.reg = PluginsRegistry(self.plugins)
 
@@ -227,7 +228,7 @@ class PluginsRegistryTest(unittest.TestCase):
 
     def test_repr(self):
         self.plugin_ep.__repr__ = lambda _: "PluginEntryPoint#mock"
-        self.assertEqual("PluginsRegistry(set([PluginEntryPoint#mock]))",
+        self.assertEqual("PluginsRegistry(PluginEntryPoint#mock)",
                          repr(self.reg))
 
     def test_str(self):


### PR DESCRIPTION
```
(venv)root@le:~/lets-encrypt-preview# letsencrypt -vv auth
DEBUG:root:Logging level set at 10
Traceback (most recent call last):
File "/usr/lib/python2.7/logging/__init__.py", line 859, in emit
msg = self.format(record)
File "/usr/lib/python2.7/logging/__init__.py", line 732, in format
return fmt.format(record)
File "/usr/lib/python2.7/logging/__init__.py", line 471, in format
record.message = record.getMessage()
File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
msg = msg % self.args
File "/root/lets-encrypt-preview/letsencrypt/plugins/disco.py", line 219, in __repr__
self.__class__.__name__, set(self._plugins.itervalues()))
TypeError: unhashable type: 'PluginEntryPoint'
Logged from file cli.py, line 356
Traceback (most recent call last):
File "/root/lets-encrypt-preview/venv/bin/letsencrypt", line 9, in <module>
load_entry_point('letsencrypt==0.1', 'console_scripts', 'letsencrypt')()
File "/root/lets-encrypt-preview/letsencrypt/cli.py", line 356, in main
logging.debug("Discovered plugins: %r", plugins)
File "/usr/lib/python2.7/logging/__init__.py", line 1630, in debug
root.debug(msg, *args, **kwargs)
File "/usr/lib/python2.7/logging/__init__.py", line 1148, in debug
self._log(DEBUG, msg, args, **kwargs)
File "/usr/lib/python2.7/logging/__init__.py", line 1279, in _log
self.handle(record)
File "/usr/lib/python2.7/logging/__init__.py", line 1289, in handle
self.callHandlers(record)
File "/usr/lib/python2.7/logging/__init__.py", line 1329, in callHandlers
hdlr.handle(record)
File "/usr/lib/python2.7/logging/__init__.py", line 757, in handle
self.emit(record)
File "/root/lets-encrypt-preview/letsencrypt/log.py", line 40, in emit
for line in record.getMessage().splitlines():
File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
msg = msg % self.args
File "/root/lets-encrypt-preview/letsencrypt/plugins/disco.py", line 219, in __repr__
self.__class__.__name__, set(self._plugins.itervalues()))
TypeError: unhashable type: 'PluginEntryPoint'
```