### PR TITLE
Do not depend on letsencrypt_apache in core

### DIFF
--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -56,8 +56,7 @@ class DetermineAccountTest(unittest.TestCase):
 class RollbackTest(unittest.TestCase):
     """Test the rollback function."""
     def setUp(self):
-        from letsencrypt_apache.configurator import ApacheConfigurator
-        self.m_install = mock.MagicMock(spec=ApacheConfigurator)
+        self.m_install = mock.MagicMock()
 
     @classmethod
     def _call(cls, checkpoints, side_effect):

--- a/letsencrypt/tests/revoker_test.py
+++ b/letsencrypt/tests/revoker_test.py
@@ -12,8 +12,6 @@ from letsencrypt import errors
 from letsencrypt import le_util
 from letsencrypt.display import util as display_util
 
-from letsencrypt_apache import configurator
-
 
 class RevokerBase(unittest.TestCase):  # pylint: disable=too-few-public-methods
     """Base Class for Revoker Tests."""
@@ -60,8 +58,7 @@ class RevokerTest(RevokerBase):
         self._store_certs()
 
         self.revoker = Revoker(
-            mock.MagicMock(spec=configurator.ApacheConfigurator),
-            self.mock_config)
+            installer=mock.MagicMock(), config=self.mock_config)
 
     def tearDown(self):
         shutil.rmtree(self.backup_dir)


### PR DESCRIPTION
It should be possible to run and test core without having to install any of the plugins.