### PR TITLE
fix some nginxparser issues

### DIFF
--- a/letsencrypt_nginx/tests/nginxparser_test.py
+++ b/letsencrypt_nginx/tests/nginxparser_test.py
@@ -84,6 +84,26 @@ class TestRawNginxParser(unittest.TestCase):
               ]]]]]
         )
 
+    def test_parse_from_file2(self):
+        parsed = load(open(util.get_data_filename('edge_cases.conf')))
+        self.assertEqual(
+            parsed,
+            [[['server'], [['server_name', 'simple']]],
+             [['server'],
+              [['server_name', 'with.if'],
+               [['location', '~', '^/services/.+$'],
+                [[['if', '($request_filename ~* \\.(ttf|woff)$)'],
+                  [['add_header', 'Access-Control-Allow-Origin "*"']]]]]]],
+             [['server'],
+              [['server_name', 'with.complicated.headers'],
+               [['location', '~*', '\\.(?:gif|jpe?g|png)$'],
+                [['add_header', 'Pragma public'],
+                 ['add_header',
+                  'Cache-Control  \'public, must-revalidate, proxy-revalidate\''
+                  ' "test,;{}" foo'],
+                 ['blah', '"hello;world"'],
+                 ['try_files', '$uri @rewrites']]]]]])
+
     def test_dump_as_file(self):
         parsed = load(open(util.get_data_filename('nginx.conf')))
         parsed[-1][-1].append([['server'],

--- a/letsencrypt_nginx/tests/testdata/etc_nginx/edge_cases.conf
+++ b/letsencrypt_nginx/tests/testdata/etc_nginx/edge_cases.conf
@@ -1,0 +1,27 @@
+# This is not a valid nginx config file but it tests edge cases in valid nginx syntax
+
+server {
+  server_name simple;
+}
+
+server {
+  server_name with.if;
+  location ~ ^/services/.+$ {
+        if ($request_filename ~* \.(ttf|woff)$) {
+      add_header          Access-Control-Allow-Origin "*";
+    }
+  }
+}
+
+server {
+  server_name with.complicated.headers;
+
+  location ~* \.(?:gif|jpe?g|png)$ {
+
+    add_header  Pragma public;
+    add_header  Cache-Control  'public, must-revalidate, proxy-revalidate' "test,;{}" foo;
+    blah  "hello;world";
+
+    try_files   $uri @rewrites;
+  }
+}


### PR DESCRIPTION
This fixes some issues with nginxparser that I discovered while running it on a fairly-complicated production nginx config.

1. Match "if" statements, fix #415 
2. Allow special characters in nginx directives when enclosed in single or double quotes.

