### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:trusty
+
+EXPOSE 443
+
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /opt
+ADD bootstrap/ubuntu.sh ./bootstrap/ubuntu.sh
+
+# Install and clean in one step to avoid large docker history.
+# Install without virtualenv, since this is in a containerized
+# environment anyway.
+RUN \
+  bootstrap/ubuntu.sh no_venv && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Gather all the requirements to run setup.py
+ADD setup.py README.rst CHANGES.rst MANIFEST.in ./
+ADD letsencrypt ./letsencrypt/
+ADD acme ./acme/
+ADD letsencrypt_apache ./letsencrypt_apache/
+ADD letsencrypt_nginx ./letsencrypt_nginx/
+
+RUN python setup.py install
+
+VOLUME /etc/letsencrypt /var/lib/letsencrypt
+CMD [ "/bin/bash" ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,11 @@ VAGRANTFILE_API_VERSION = "2"
 $ubuntu_setup_script = <<SETUP_SCRIPT
 cd /vagrant
 sudo ./bootstrap/ubuntu.sh
+
+# For some reason running setup.py w/o virtualenv in vagrant fails
 if [ ! -d "venv" ]; then
   virtualenv --no-site-packages -p python2 venv
-  ./venv/bin/pip install -r requirements.txt -e .[dev,docs,testing]
+  ./venv/bin/python setup.py install
 fi
 SETUP_SCRIPT
 

--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -42,5 +42,3 @@ else
 fi
 
 apt-get install -y --no-install-recommends $packages
-
-ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/

--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -16,7 +16,7 @@ apt-get update
 #           #276, https://github.com/martinpaljak/M2Crypto/issues/62,
 #           M2Crypto setup.py:add_multiarch_paths
 
-common_packages="python python-setuptools python-dev gcc swig dialog libaugeas0 libssl-dev openssl libffi-dev"
+common_packages="python python-setuptools python-dev gcc swig dialog libaugeas0 libssl-dev openssl libffi-dev dpkg-dev ca-certificates"
 
 if [ "$1" = "no_venv" ]
 then

--- a/bootstrap/_deb_common.sh
+++ b/bootstrap/_deb_common.sh
@@ -10,26 +10,37 @@
 #     - 7.8 "wheezy" (x64)
 #     - 8.0 "jessie" (x64)
 
-# virtualenv binary can be found in different packages depending on
-# distro version (#346)
-distro=$(lsb_release -si)
-# 6.0.10 => 60, 14.04 => 1404
-version=$(lsb_release -sr | awk -F '.' '{print $1 $2}')
-if [ "$distro" = "Ubuntu" -a "$version" -ge 1410 ]
-then
-  virtualenv="virtualenv"
-elif [ "$distro" = "Debian" -a "$version" -ge 80 ]
-then
-  virtualenv="virtualenv"
-else
-  virtualenv="python-virtualenv"
-fi
+apt-get update
 
 # dpkg-dev: dpkg-architecture binary necessary to compile M2Crypto, c.f.
 #           #276, https://github.com/martinpaljak/M2Crypto/issues/62,
 #           M2Crypto setup.py:add_multiarch_paths
 
-apt-get update
-apt-get install -y --no-install-recommends \
-  python python-setuptools "$virtualenv" python-dev gcc swig \
-  dialog libaugeas0 libssl-dev libffi-dev ca-certificates dpkg-dev
+common_packages="python python-setuptools python-dev gcc swig dialog libaugeas0 libssl-dev openssl libffi-dev"
+
+if [ "$1" = "no_venv" ]
+then
+  packages="$common_packages"
+else
+
+  # virtualenv binary can be found in different packages depending on
+  # distro version (#346)
+  distro=$(lsb_release -si)
+  # 6.0.10 => 60, 14.04 => 1404
+  version=$(lsb_release -sr | awk -F '.' '{print $1 $2}')
+  if [ "$distro" = "Ubuntu" -a "$version" -ge 1410 ]
+  then
+    virtualenv="virtualenv"
+  elif [ "$distro" = "Debian" -a "$version" -ge 80 ]
+  then
+    virtualenv="virtualenv"
+  else
+    virtualenv="python-virtualenv"
+  fi
+
+  packages="$virtualenv $common_packages"
+fi
+
+apt-get install -y --no-install-recommends $packages
+
+ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+production:
+  build: .
+  ports:
+    - "443:443"
+
+# a more vagrant-like setup for development
+development:
+  build: .
+  ports:
+    - "443:443"
+  volumes:
+    - .:/opt/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,7 +48,6 @@ synced to ``/vagrant``, so you can get started with:
 
   vagrant ssh
   cd /vagrant
-  ./venv/bin/pip install -r requirements.txt
   sudo ./venv/bin/letsencrypt
 
 Support for other Linux distributions coming soon.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,6 +63,17 @@ Support for other Linux distributions coming soon.
 .. _related issue: https://github.com/ClusterHQ/flocker/issues/516
 
 
+Docker
+------
+
+If you use Docker, Let's Encrypt provides a Dockerfile to simplify
+setup of your development environment in an Ubuntu 14.04 LTS
+container. To set it up, you'll need both docker and docker-compose.
+Simply run ``docker-compose run development``. All requirements are
+installed globally in the container, so from there all you need to
+run is ``letsencrypt``.
+
+
 Code components and layout
 ==========================
 


### PR DESCRIPTION
Add support for docker.  This is mainly for development, as it is yet unclear to me how production support might work, given that Let's Encrypt operates on active webserver config files.  For development, I have Docker more or less mimic the way Vagrant works - install all the requirements in the build phase of the image, then mount the host repo to the guest for data sharing.