### PR TITLE
Inelegant approach to support --renewer-config-file command-line argument

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -340,6 +340,9 @@ def _paths_parser(parser):
     add("--chain-path", default=flag_default("chain_path"),
         help=config_help("chain_path"))
 
+    add("--renewer-config-file", default=flag_default("renewer_config_file"),
+        help=config_help("renewer_config_file"))
+
     add("--enroll-autorenew", default=None, action="store_true",
         help=config_help("enroll_autorenew"))
 

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -182,9 +182,19 @@ class Client(object):
             authenticator).name
         if installer is not None:
             self.config.namespace.installer = plugins.find_init(installer).name
+
+        # XXX: We clearly need a more general and correct way of getting
+        # options into the configobj for the RenewableCert instance.
+        # This is a quick-and-dirty way to do it to allow integration
+        # testing to start.  (Note that the config parameter to new_lineage
+        # ideally should be a ConfigObj, but in this case a dict will be
+        # accepted in practice.)
+        params = vars(self.config.namespace)
+        config = {"renewer_config_file":
+                  params["renewer_config_file"]} if "renewer_config_file" in params else None
         return storage.RenewableCert.new_lineage(domains[0], cert_pem,
                                                  privkey, chain_pem,
-                                                 vars(self.config.namespace))
+                                                 params, config)
 
     def obtain_certificate(self, domains):
         """Public method to obtain a certificate for the specified domains

--- a/letsencrypt/constants.py
+++ b/letsencrypt/constants.py
@@ -22,6 +22,7 @@ CLI_DEFAULTS = dict(
     certs_dir="/etc/letsencrypt/certs",
     cert_path="/etc/letsencrypt/certs/cert-letsencrypt.pem",
     chain_path="/etc/letsencrypt/certs/chain-letsencrypt.pem",
+    renewer_config_file="/etc/letsencrypt/renewer.conf",
     test_mode=False,
 )
 """Defaults for CLI flags and `.IConfig` attributes."""

--- a/letsencrypt/interfaces.py
+++ b/letsencrypt/interfaces.py
@@ -176,6 +176,9 @@ class IConfig(zope.interface.Interface):
     le_vhost_ext = zope.interface.Attribute(
         "SSL vhost configuration extension.")
 
+    renewer_config_file = zope.interface.Attribute(
+        "Location of renewal configuration file.")
+
     enroll_autorenew = zope.interface.Attribute(
         "Register this certificate in the database to be renewed"
         " automatically.")


### PR DESCRIPTION
This commit allows the client to accept a `--renewer-config-file` argument which specifies the location of the renewer configuration file that provides defaults for where to save renewal-enrolled certs.  These defaults supersede those that would otherwise have been provided by `constants.py`.  (The ability to do this was already available in `storage.py` but there was previously no way to make use of it because there was no way for the options to be provided on the command line.)

For integration testing, you can make a file, say `/tmp/tmp.muglQrnKEA`, containing the following lines:

```
renewal_configs_dir = /tmp/tmp.sOKNLm86qy/configs
archive_dir = /tmp/tmp.sOKNLm86qy/archive
live_dir = /tmp/tmp.sOKNLm86qy/live
```

Then if you invoke the client with `--renewer-config-file /tmp/tmp.muglQrnKEA`, the renewer code will use these paths as the default location for saving stuff, in lieu of the defaults locations under `/etc/letsencrypt`.  I think the client will be willing to create `configs`, `archive`, and `live` if they don't already exist.

Note that other parts of the code might still try to write files to `/etc` for historical reasons (which is now obsolete behavior that should be phased out), but those parts can be controlled by previously-existing command-line options like `--work-dir`.  This new command-line option affects only the renewer enrollment functionality invoked via `storage.RenewableCert.new_lineage`, which had previously insisted on writing to `/etc/letsencrypt` and couldn't be induced to do otherwise.

Fixes #436.  Ought to be superseded by a comprehensive approach to #446 and possibly also a future client CLI redesign.  Cc @jsha.