### PR TITLE
Reporter

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -1,5 +1,6 @@
 """Let's Encrypt CLI."""
 # TODO: Sanity check all input.  Be sure to avoid shell code etc...
+import atexit
 import argparse
 import logging
 import os
@@ -20,6 +21,7 @@ from letsencrypt import errors
 from letsencrypt import interfaces
 from letsencrypt import le_util
 from letsencrypt import log
+from letsencrypt import notifier
 
 from letsencrypt.display import util as display_util
 from letsencrypt.display import ops as display_ops
@@ -346,6 +348,11 @@ def main(args=sys.argv[1:]):
     else:
         displayer = display_util.NcursesDisplay()
     zope.component.provideUtility(displayer)
+
+    # Notifier
+    notify = notifier.Notifier()
+    zope.component.provideUtility(notify)
+    atexit.register(notify.print_messages)
 
     # Logging
     level = -args.verbose_count * 10

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -361,7 +361,7 @@ def main(args=sys.argv[1:]):
         displayer = display_util.NcursesDisplay()
     zope.component.provideUtility(displayer)
 
-    # Notifier
+    # Reporter
     report = reporter.Reporter()
     zope.component.provideUtility(report)
     atexit.register(report.print_messages)

--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -21,7 +21,7 @@ from letsencrypt import errors
 from letsencrypt import interfaces
 from letsencrypt import le_util
 from letsencrypt import log
-from letsencrypt import notifier
+from letsencrypt import reporter
 
 from letsencrypt.display import util as display_util
 from letsencrypt.display import ops as display_ops
@@ -363,9 +363,9 @@ def main(args=sys.argv[1:]):
     zope.component.provideUtility(displayer)
 
     # Notifier
-    notify = notifier.Notifier()
-    zope.component.provideUtility(notify)
-    atexit.register(notify.print_messages)
+    report = reporter.Reporter()
+    zope.component.provideUtility(report)
+    atexit.register(report.print_messages)
 
     # Logging
     level = -args.verbose_count * 10

--- a/letsencrypt/interfaces.py
+++ b/letsencrypt/interfaces.py
@@ -346,3 +346,30 @@ class IValidator(zope.interface.Interface):
 
     def hsts(name):
         """Verify HSTS header is enabled."""
+
+
+class INotify(zope.interface.Interface):
+    """Interface to collect and display information to the user."""
+
+    HIGH_PRIORITY = zope.interface.Attribute(
+        "Used to denote high priority messages")
+    MEDIUM_PRIORITY = zope.interface.Attribute(
+        "Used to denote medium priority messages")
+    LOW_PRIORITY = zope.interface.Attribute(
+        "Used to denote low priority messages")
+
+    def add_message(self, msg, priority, on_crash=False):
+        """Adds msg to the list of messages to be printed.
+
+        :param str msg: Message to be displayed to the user.
+
+        :param int priority: One of HIGH_PRIORITY, MEDIUM_PRIORITY, or
+            LOW_PRIORITY.
+
+        :param bool on_crash: Whether or not the message should be printed if
+            the program exits abnormally.
+
+        """
+
+    def print_messages(self):
+        """Prints messages to the user and clears the message queue."""

--- a/letsencrypt/interfaces.py
+++ b/letsencrypt/interfaces.py
@@ -353,7 +353,7 @@ class IValidator(zope.interface.Interface):
         """Verify HSTS header is enabled."""
 
 
-class INotify(zope.interface.Interface):
+class IReporter(zope.interface.Interface):
     """Interface to collect and display information to the user."""
 
     HIGH_PRIORITY = zope.interface.Attribute(

--- a/letsencrypt/notifier.py
+++ b/letsencrypt/notifier.py
@@ -1,0 +1,57 @@
+"""Collects and displays information to the user."""
+import collections
+import Queue
+import sys
+import textwrap
+
+import zope.interface
+
+from letsencrypt import interfaces
+
+
+class Notifier(object):
+    """Collects and displays information to the user.
+
+    :ivar `Queue.PriorityQueue` messages: Messages to be displayed to the user.
+
+    """
+
+    zope.interface.implements(interfaces.INotify)
+
+    HIGH_PRIORITY, MEDIUM_PRIORITY, LOW_PRIORITY = xrange(3)
+    _msg_type = collections.namedtuple('Msg', 'priority, text, on_crash')
+
+    def __init__(self):
+        self.messages = Queue.PriorityQueue()
+
+    def add_message(self, msg, priority, on_crash=False):
+        """Adds msg to the list of messages to be printed.
+
+        :param str msg: Message to be displayed to the user.
+
+        :param int priority: One of HIGH_PRIORITY, MEDIUM_PRIORITY, or
+            LOW_PRIORITY.
+
+        :param bool on_crash: Whether or not the message should be printed if
+            the program exits abnormally.
+
+        """
+        assert priority >= self.HIGH_PRIORITY and priority <= self.LOW_PRIORITY
+        self.messages.put(self._msg_type(priority, msg, on_crash))
+
+    def print_messages(self):
+        """Prints messages to the user and clears the message queue.
+
+        If there is an unhandled exception, only messages for which on_crash is
+        True are printed.
+
+        """
+        if not self.messages.empty():
+            no_exception = sys.exc_info()[0] is None
+            print 'IMPORTANT NOTES:'
+            wrapper = textwrap.TextWrapper(initial_indent=' - ',
+                                           subsequent_indent=' '*3)
+        while not self.messages.empty():
+            msg = self.messages.get()
+            if no_exception or msg.on_crash:
+                print wrapper.fill(msg.text)

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -1,0 +1,73 @@
+"""Tests for letsencrypt/reporter.py"""
+import StringIO
+import sys
+import unittest
+
+
+class ReporterTest(unittest.TestCase):
+    def setUp(self):
+        from letsencrypt import reporter
+        self.reporter = reporter.Reporter()
+
+        self.old_stdout = sys.stdout
+        sys.stdout = StringIO.StringIO()
+
+    def tearDown(self):
+        sys.stdout = self.old_stdout
+
+    def test_tty_print_empty(self):
+        sys.stdout.isatty = lambda: True
+        self.test_no_tty_print_empty()
+
+    def test_no_tty_print_empty(self):
+        self.reporter.print_messages()
+        self.assertEqual(sys.stdout.getvalue(), "")
+        try:
+            raise ValueError
+        except ValueError:
+            self.reporter.print_messages()
+        self.assertEqual(sys.stdout.getvalue(), "")
+
+    def test_tty_successful_exit(self):
+        sys.stdout.isatty = lambda: True
+        self._successful_exit_common()
+
+    def test_no_tty_successful_exit(self):
+        self._successful_exit_common()
+
+    def test_tty_unsuccessful_exit(self):
+        sys.stdout.isatty = lambda: True
+        self._unsuccessful_exit_common()
+
+    def test_no_tty_unsuccessful_exit(self):
+        self._unsuccessful_exit_common()
+
+    def _successful_exit_common(self):
+        self._add_messages()
+        self.reporter.print_messages()
+        output = sys.stdout.getvalue()
+        self.assertTrue("IMPORTANT NOTES:" in output)
+        self.assertTrue("High" in output)
+        self.assertTrue("Med" in output)
+        self.assertTrue("Low" in output)
+
+    def _unsuccessful_exit_common(self):
+        self._add_messages()
+        try:
+            raise ValueError
+        except ValueError:
+            self.reporter.print_messages()
+        output = sys.stdout.getvalue()
+        self.assertTrue("IMPORTANT NOTES:" in output)
+        self.assertTrue("High" in output)
+        self.assertTrue("Med" not in output)
+        self.assertTrue("Low" not in output)
+
+    def _add_messages(self):
+        self.reporter.add_message("High", self.reporter.HIGH_PRIORITY, True)
+        self.reporter.add_message("Med", self.reporter.MEDIUM_PRIORITY)
+        self.reporter.add_message("Low", self.reporter.LOW_PRIORITY)
+
+
+if __name__ == "__main__":
+    unittest.main() # pragma: no cover


### PR DESCRIPTION
This is an implementation a system we can use throughout the client to report messages on program exit as described in #271.

There is more work to be done in the following areas:
* Currently, no messages are being added to this system. You can add messages using zope from anywhere in the client. `zope.component.getUtility(letsencrypt.interfaces.IReporter)` will return the instance of the Reporter created by letsencrypt/cli.py and `add_messsage()` can be called. I will do some work on adding these messages in the client where I am aware they are needed.
* More work should be done on the best way to display these messages. Currently, the messages are sorted, with higher priority messages appearing above lower priority messages and the messages are always output to the console. Additionally, if stdout isn't redirected, the header and high priority messages are output in bold text. An example of this output is shown here, where I somewhat arbitrarily marked the first message as high priority, the next two as medium priority, and the final as a low priority message.

>**IMPORTANT NOTES:**
> - **if you lose your account credentials, your recovery method will be**
>   **emails sent to username@you.just.gave.us.com | the following token**
>   **"FOGGY IMPROBABILITY QUIZZICAL HIPPOPOTAMUS"; you must write that**
>   **-down and put it in a safe place**
> - automatic renewals have been configured for your certs; they are
>   controlled from /etc/lets-encrypt/renewal.cfg
> - your account credentials, keys, certs, chains etc live in
>   directories below /etc/lets-encrypt/. Please make a secure backup.
> - secure mode is enabled for your site. Run lets-encrypt-nginx
>   --security-status for more info.

Please let me know if there is anything I can/could/should change in order for this to better satisfy our needs.