### PR TITLE
Use timedelta instead of now.month + 1 (partially fixes: #456).

### DIFF
--- a/letsencrypt/tests/acme_util.py
+++ b/letsencrypt/tests/acme_util.py
@@ -125,10 +125,9 @@ def gen_authzr(authz_status, domain, challs, statuses, combos=True):
     if combos:
         authz_kwargs.update({"combinations": gen_combos(challbs)})
     if authz_status == messages2.STATUS_VALID:
-        now = datetime.datetime.now()
         authz_kwargs.update({
             "status": authz_status,
-            "expires": datetime.datetime(now.year, now.month + 1, now.day),
+            "expires": datetime.datetime.now() + datetime.timedelta(days=31),
         })
     else:
         authz_kwargs.update({


### PR DESCRIPTION
`ValueError: day is out of range for month`