### PR TITLE
Duplicate output fix

### DIFF
--- a/letsencrypt/plugins/standalone/authenticator.py
+++ b/letsencrypt/plugins/standalone/authenticator.py
@@ -266,6 +266,7 @@ class StandaloneAuthenticator(common.Plugin):
         signal.signal(signal.SIGUSR1, self.client_signal_handler)
         signal.signal(signal.SIGUSR2, self.client_signal_handler)
 
+        sys.stdout.flush()
         fork_result = os.fork()
         Crypto.Random.atfork()
         if fork_result:


### PR DESCRIPTION
I found a small bug where letsencrypt output was duplicated when using the standalone authenticator with redirected output. The reason for this was that buffered output was duplicated in the child process created by the standalone authenticator. To fix this, I simply added a call to `sys.stdout.flush()` before `os.fork()`.