### PR TITLE
Core reporter messages

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -377,7 +377,7 @@ def main(args=sys.argv[1:]):
     # Reporter
     report = reporter.Reporter()
     zope.component.provideUtility(report)
-    atexit.register(report.print_messages)
+    atexit.register(report.atexit_print_messages)
 
     # Logging
     level = -args.verbose_count * 10

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -99,6 +99,15 @@ class Client(object):
                 raise errors.LetsEncryptClientError("Must agree to TOS")
 
         self.account.save()
+        reporter = zope.component.getUtility(interfaces.IReporter)
+        reporter.add_message(
+            "Your account credentials have been saved in your Let's Encrypt "
+            "configuration directory at {0}. You should make a secure backup "
+            "of this folder now. This configuration directory will also "
+            "contain certificates and private keys obtained by Let's Encrypt "
+            "so making regular backups of this folder is ideal.".format(
+                self.config.config_dir),
+            reporter.HIGH_PRIORITY, True)
 
     def obtain_certificate(self, domains, csr=None):
         """Obtains a certificate from the ACME server.

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -56,6 +56,8 @@ class Reporter(object):
         :param int pid: Process ID
 
         """
+        # This ensures that messages are only printed from the process that
+        # created the Reporter.
         if pid == os.getpid():
             self.print_messages()
 
@@ -64,8 +66,7 @@ class Reporter(object):
 
         If there is an unhandled exception, only messages for which
         ``on_crash`` is ``True`` are printed.
-
-        """
+"""
         bold_on = False
         if not self.messages.empty():
             no_exception = sys.exc_info()[0] is None

--- a/letsencrypt/reporter.py
+++ b/letsencrypt/reporter.py
@@ -1,5 +1,7 @@
 """Collects and displays information to the user."""
 import collections
+import logging
+import os
 import Queue
 import sys
 import textwrap
@@ -46,6 +48,16 @@ class Reporter(object):
         """
         assert self.HIGH_PRIORITY <= priority <= self.LOW_PRIORITY
         self.messages.put(self._msg_type(priority, msg, on_crash))
+        logging.info("Reporting to user: %s", msg)
+
+    def atexit_print_messages(self, pid=os.getpid()):
+        """Function to be registered with atexit to print messages.
+
+        :param int pid: Process ID
+
+        """
+        if pid == os.getpid():
+            self.print_messages()
 
     def print_messages(self):
         """Prints messages to the user and clears the message queue.
@@ -59,7 +71,7 @@ class Reporter(object):
             no_exception = sys.exc_info()[0] is None
             bold_on = sys.stdout.isatty()
             if bold_on:
-                sys.stdout.write(self._BOLD)
+                print self._BOLD
             print 'IMPORTANT NOTES:'
             wrapper = textwrap.TextWrapper(initial_indent=' - ',
                                            subsequent_indent=(' ' * 3))

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -5,6 +5,7 @@ import pkg_resources
 import shutil
 import tempfile
 
+import configobj
 import mock
 
 from letsencrypt import account
@@ -35,6 +36,48 @@ class ClientTest(unittest.TestCase):
         self.network2.Network.assert_called_once_with(
             mock.ANY, mock.ANY, verify_ssl=True)
 
+    @mock.patch("letsencrypt.client.zope.component.getUtility")
+    def test_report_new_account(self, mock_zope):
+        self.config.config_dir = "/usr/bin/coffee"
+        self.account.recovery_token = "ECCENTRIC INVISIBILITY RHINOCEROS"
+        self.account.email = "rhino@jungle.io"
+
+        self.client._report_new_account()
+        call_list = mock_zope().add_message.call_args_list
+        self.assertTrue(self.config.config_dir in call_list[0][0][0])
+        self.assertTrue(self.account.recovery_token in call_list[1][0][0])
+        self.assertTrue(self.account.email in call_list[1][0][0])
+
+    @mock.patch("letsencrypt.client.zope.component.getUtility")
+    def test_report_renewal_status(self, mock_zope):
+        cert = mock.MagicMock()
+        cert.configuration = configobj.ConfigObj()
+        cert.configuration["renewal_configs_dir"] = "/etc/letsencrypt/configs"
+
+        cert.configuration["autorenew"] = "True"
+        cert.configuration["autodeploy"] = "True"
+        self.client._report_renewal_status(cert)
+        msg = mock_zope().add_message.call_args[0][0]
+        self.assertTrue("renewal and deployment has been" in msg)
+        self.assertTrue(cert.configuration["renewal_configs_dir"] in msg)
+
+        cert.configuration["autorenew"] = "False"
+        self.client._report_renewal_status(cert)
+        msg = mock_zope().add_message.call_args[0][0]
+        self.assertTrue("deployment but not automatic renewal" in msg)
+        self.assertTrue(cert.configuration["renewal_configs_dir"] in msg)
+    
+        cert.configuration["autodeploy"] = "False"
+        self.client._report_renewal_status(cert)
+        msg = mock_zope().add_message.call_args[0][0]
+        self.assertTrue("renewal and deployment has not" in msg)
+        self.assertTrue(cert.configuration["renewal_configs_dir"] in msg)
+
+        cert.configuration["autorenew"] = "True"
+        self.client._report_renewal_status(cert)
+        msg = mock_zope().add_message.call_args[0][0]
+        self.assertTrue("renewal but not automatic deployment" in msg)
+        self.assertTrue(cert.configuration["renewal_configs_dir"] in msg)
 
 class DetermineAccountTest(unittest.TestCase):
     """Tests for letsencrypt.client.determine_authenticator."""

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -38,6 +38,7 @@ class ClientTest(unittest.TestCase):
 
     @mock.patch("letsencrypt.client.zope.component.getUtility")
     def test_report_new_account(self, mock_zope):
+        # pylint: disable=protected-access
         self.config.config_dir = "/usr/bin/coffee"
         self.account.recovery_token = "ECCENTRIC INVISIBILITY RHINOCEROS"
         self.account.email = "rhino@jungle.io"
@@ -50,6 +51,7 @@ class ClientTest(unittest.TestCase):
 
     @mock.patch("letsencrypt.client.zope.component.getUtility")
     def test_report_renewal_status(self, mock_zope):
+        # pylint: disable=protected-access
         cert = mock.MagicMock()
         cert.configuration = configobj.ConfigObj()
         cert.configuration["renewal_configs_dir"] = "/etc/letsencrypt/configs"
@@ -66,7 +68,7 @@ class ClientTest(unittest.TestCase):
         msg = mock_zope().add_message.call_args[0][0]
         self.assertTrue("deployment but not automatic renewal" in msg)
         self.assertTrue(cert.configuration["renewal_configs_dir"] in msg)
-    
+
         cert.configuration["autodeploy"] = "False"
         self.client._report_renewal_status(cert)
         msg = mock_zope().add_message.call_args[0][0]

--- a/letsencrypt/tests/proof_of_possession_test.py
+++ b/letsencrypt/tests/proof_of_possession_test.py
@@ -69,7 +69,7 @@ class ProofOfPossessionTest(unittest.TestCase):
     def test_perform_no_input(self):
         self.assertTrue(self.proof_of_pos.perform(self.achall).verify())
 
-    @mock.patch("letsencrypt.recovery_token.zope.component.getUtility")
+    @mock.patch("letsencrypt.proof_of_possession.zope.component.getUtility")
     def test_perform_with_input(self, mock_input):
         # Remove the matching certificate
         self.installer.get_all_certs_keys.return_value.pop()

--- a/letsencrypt/tests/reporter_test.py
+++ b/letsencrypt/tests/reporter_test.py
@@ -30,6 +30,15 @@ class ReporterTest(unittest.TestCase):
             self.reporter.print_messages()
         self.assertEqual(sys.stdout.getvalue(), "")
 
+    def test_atexit_print_messages(self):
+        self._add_messages()
+        self.reporter.atexit_print_messages()
+        output = sys.stdout.getvalue()
+        self.assertTrue("IMPORTANT NOTES:" in output)
+        self.assertTrue("High" in output)
+        self.assertTrue("Med" in output)
+        self.assertTrue("Low" in output)
+
     def test_tty_successful_exit(self):
         sys.stdout.isatty = lambda: True
         self._successful_exit_common()


### PR DESCRIPTION
Added core messages to the reporter about recovery methods, account credentials, and renewal status, similar to those suggested in #271. More messages can be added to the reporter (such as from the plugins), but I believe this this conveys some of the most critical information to the user.

Additionally, I fixed a bug with the reporter that caused the reporter to produce duplicate output when used with the standalone authenticator.