### PR TITLE
requirements.txt: no editable (-e) mode, no "." install.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,7 +48,7 @@ synced to ``/vagrant``, so you can get started with:
 
   vagrant ssh
   cd /vagrant
-  ./venv/bin/pip install -r requirements.txt
+  ./venv/bin/pip install -r requirements.txt .[dev,docs,testing]
   sudo ./venv/bin/letsencrypt
 
 Support for other Linux distributions coming soon.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -71,7 +71,7 @@ Installation
 .. code-block:: shell
 
    virtualenv --no-site-packages -p python2 venv
-   ./venv/bin/pip install -r requirements.txt
+   ./venv/bin/pip install -r requirements.txt .
 
 
 Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 # https://github.com/bw2/ConfigArgParse/issues/17
--e git+https://github.com/kuba/ConfigArgParse.git@python2.6#egg=ConfigArgParse
--e .
+git+https://github.com/kuba/ConfigArgParse.git@python2.6#egg=ConfigArgParse

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,12 @@ setenv =
 [testenv:cover]
 basepython = python2.7
 commands =
-    pip install -e .[testing]
+    pip install -r requirements.txt -e .[testing]
     ./tox.cover.sh
 
 [testenv:lint]
 # recent versions of pylint do not support Python 2.6 (#97, #187)
 basepython = python2.7
 commands =
-    pip install -e .[dev]
+    pip install -r requirements.txt -e .[dev]
     pylint --rcfile=.pylintrc letsencrypt acme letsencrypt_apache letsencrypt_nginx


### PR DESCRIPTION
 `requirements.txt` unnecessarily defaulted to editable mode. Tested locally on sid.