### PR TITLE
Don't suggest optional email.

### DIFF
--- a/letsencrypt/account.py
+++ b/letsencrypt/account.py
@@ -186,7 +186,7 @@ class Account(object):
         """
         while True:
             code, email = zope.component.getUtility(interfaces.IDisplay).input(
-                "Enter email address (optional, press Enter to skip)")
+                "Enter email address")
 
             if code == display_util.OK:
                 try:


### PR DESCRIPTION
Email is still optional, by the same mechanism, but removing the suggestion to
leave it out we will greatly increase the percentage of users that supply one,
which in turn will reduce customer support requests.