### PR TITLE
Make sure cleanup_challenges happens

### DIFF
--- a/letsencrypt/auth_handler.py
+++ b/letsencrypt/auth_handler.py
@@ -134,9 +134,11 @@ class AuthHandler(object):
             self._send_responses(self.cont_c, cont_resp, chall_update))
 
         # Check for updated status...
-        self._poll_challenges(chall_update, best_effort)
-        # This removes challenges from self.dv_c and self.cont_c
-        self._cleanup_challenges(active_achalls)
+        try:
+            self._poll_challenges(chall_update, best_effort)
+        finally:
+            # This removes challenges from self.dv_c and self.cont_c
+            self._cleanup_challenges(active_achalls)
 
     def _send_responses(self, achalls, resps, chall_update):
         """Send responses and make sure errors are handled.


### PR DESCRIPTION
If the authorization procedure fails, currently the authenticator's cleanup isn't called.