### PR TITLE
Fix for functools32 that works with Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ after_success: '[ "$TOXENV" == "cover" ] && coveralls'
 # matrix, which allows us to clearly distinguish which component under
 # test has failed
 env:
+  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=lint
   - TOXENV=cover

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -95,7 +95,7 @@ backslash):
 .. code-block:: shell
 
    SWIG_FEATURES="-includeall -D__`uname -m`__-I/usr/include/openssl" \
-   ./venv/bin/pip install -r requirements.txt functools32 .
+   ./venv/bin/pip install -r requirements.txt .
 
 
 Installation

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -35,8 +35,8 @@ In general:
   .. _new-swig:
   .. note:: If your operating system uses SWIG 3.0.5+, you will need
             to run ``pip install -r requirements-swig-3.0.5.txt -r
-            requirements.txt`` instead of the standard ``pip
-            install -r requirements.txt``.
+            requirements.txt .`` instead of the standard ``pip
+            install -r requirements.txt .``.
 
 * `Augeas`_ is required for the Python bindings
 
@@ -95,7 +95,7 @@ backslash):
 .. code-block:: shell
 
    SWIG_FEATURES="-includeall -D__`uname -m`__-I/usr/include/openssl" \
-   ./venv/bin/pip install -r requirements.txt functools32
+   ./venv/bin/pip install -r requirements.txt functools32 .
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'argparse',
     'ConfigArgParse',
     'configobj',
-    'jsonschema',
+    'jsonschema<2.5.1',  # https://github.com/Julian/jsonschema/issues/233
     'mock',
     'ndg-httpsclient',  # urllib3 InsecurePlatformWarning (#304)
     'parsedatetime',
@@ -53,7 +53,6 @@ install_requires = [
     # order of items in install_requires DOES matter and M2Crypto has
     # to go last, see #152
     'M2Crypto',
-    'functools32'
 ]
 
 dev_extras = [


### PR DESCRIPTION
`functools32` is problem of upstream `jsonschema` (https://github.com/Julian/jsonschema/issues/233), so it's saner to pin `jsonschema` while still maintaining Python 2.6 support. @jdkasten, please merge this PR before proceeding with anything else (FYI it shares b3be239 with #516), to make sure all other PRs are still compliant with Python 2.6. Thanks!

cc @Hainish